### PR TITLE
fix(ci): close 3 post-merge main failures (drift, scorecard pin, pr-bots checkout)

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -47,6 +47,24 @@
           { "context": "DCO" }
         ]
       }
+    },
+    {
+      "type": "code_scanning",
+      "parameters": {
+        "code_scanning_tools": [
+          {
+            "tool": "CodeQL",
+            "security_alerts_threshold": "high_or_higher",
+            "alerts_threshold": "errors"
+          }
+        ]
+      }
+    },
+    {
+      "type": "code_quality",
+      "parameters": {
+        "severity": "errors"
+      }
     }
   ],
   "bypass_actors": []

--- a/.github/workflows/pr-bots.yml
+++ b/.github/workflows/pr-bots.yml
@@ -182,6 +182,11 @@ jobs:
       - name: Find PRs that are BEHIND or DIRTY relative to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_REPO lets `gh pr ...` resolve the repo from env instead of
+          # falling back to `git config remote.origin.url`, which would
+          # error out here because we intentionally don't `actions/checkout`
+          # (no PR code reaches the runner -- see safety note at top of file).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           # GH's mergeable field returns null while GH is computing --

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -64,7 +64,13 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        # SHA pin: the v2.4.3 release uses an annotated tag, so we must
+        # pin to the *commit* SHA the tag points to (4eaacf0...), not
+        # the tag-object SHA (99c09fe...). The OSSF scorecard server's
+        # imposter-commit check verifies the commit, so pinning to the
+        # tag-object SHA fails workflow verification with
+        # "imposter commit: ... does not belong to ossf/scorecard-action".
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Three independent root causes turned 3/12 main workflows red on `7800936`. All fixed atomically.

- **F1 — Verify GitHub config (drift detection)**: SSOT (`.github/rulesets/main.json`) only declared 5 rules; live state has 7. Added the missing `code_scanning` + `code_quality` rule blocks. `gh:verify` now 0-drift locally.
- **F2 — OSSF Scorecard**: `imposter commit` error. The v2.4.3 release ships as an annotated tag, so the tag-object SHA (`99c09fe9`) differs from the commit SHA (`4eaacf05`) it points to. The OSSF server's verification checks the commit. Repinned + comment explaining the trap.
- **F3 — PR bots needs-rebase**: `fatal: not a git repository`. The job intentionally doesn't `actions/checkout` (safety rule at top of file: `pull_request_target` must never check out PR code), but gh CLI was trying to resolve repo via `git config`. Added `GH_REPO: ${{ github.repository }}` env so gh resolves from env. Preserves no-checkout posture.

None of the three were caused by CodeQL (despite that being the original hypothesis).

## Test plan

- [x] `node scripts/system/apply-github-config.mjs --verify` → ✓ No drift
- [x] `actionlint .github/workflows/{scorecard,pr-bots}.yml` → clean
- [x] `zizmor --min-severity=medium` on both → 0 findings
- [x] Pre-push hook full vitest + typecheck + format-check → all green (2945 tests, coverage gates met)
- [ ] After merge: trigger `OSSF Scorecard` via `workflow_dispatch` → must pass
- [ ] After merge: next push to main triggers `PR bots / needs-rebase` → must pass
- [ ] After merge: `Verify GitHub config (drift detection)` on the merge commit → must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository branch protection with automated security scanning enforcement
  * Improved CI/CD workflow configuration for enhanced reliability
  * Updated security tooling version pin for better verification accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->