### PR TITLE
fix(ci): treat invisible-to-token fields as not-drift in verify-gh-config

### DIFF
--- a/.github/workflows/verify-gh-config.yml
+++ b/.github/workflows/verify-gh-config.yml
@@ -27,6 +27,15 @@ on:
 permissions:
   contents: read
   issues: write
+  # NB: GITHUB_TOKEN cannot grant the `administration` scope (only PATs
+  # can). That means GET /repos/{slug} returns admin-only fields
+  # (allow_auto_merge, delete_branch_on_merge, security_and_analysis.*)
+  # as undefined here. apply-github-config.mjs treats undefined as
+  # "field not visible to this token" and skips it rather than
+  # false-positive-flagging it as drift. The drift checks that DO
+  # work under GITHUB_TOKEN: description, homepage, topics, rulesets,
+  # private vulnerability reporting -- which covers the main concerns
+  # this workflow exists to catch.
 
 concurrency:
   group: verify-gh-config-${{ github.run_id }}

--- a/scripts/system/apply-github-config.mjs
+++ b/scripts/system/apply-github-config.mjs
@@ -168,6 +168,13 @@ async function main() {
   }
 
   // ── 3. Repo settings (auto-merge, delete-branch, commit-signoff) ──
+  // `allow_auto_merge`, `delete_branch_on_merge`, and the GHAS fields
+  // below are only included in GET /repos/{slug} when the requesting
+  // token has `administration: read`. GITHUB_TOKEN in workflows cannot
+  // grant that scope (PAT-only). So in CI those fields come back
+  // undefined -- we treat that as "invisible to this token, skip"
+  // rather than false-positive-flag as drift. Local runs with an
+  // admin PAT still see the fields and catch real drift.
   const desiredSettings = {
     allow_auto_merge: true,
     delete_branch_on_merge: true,
@@ -175,7 +182,10 @@ async function main() {
     has_discussions: true,
     has_issues: true,
   };
-  const settingsDrift = Object.entries(desiredSettings).filter(([k, v]) => repoState[k] !== v);
+  const settingsDrift = Object.entries(desiredSettings).filter(([k, v]) => {
+    if (repoState[k] === undefined) return false; // field not visible to current token
+    return repoState[k] !== v;
+  });
   if (settingsDrift.length > 0) {
     driftCount++;
     console.log('▸ Repo settings');
@@ -186,15 +196,19 @@ async function main() {
   }
 
   // ── 4. GHAS toggles ────────────────────────────────────────────
+  // Same admin-only-visibility caveat as section 3. When sec[k] is
+  // undefined the token can't read this GHAS field; skip rather
+  // than assume "disabled".
   const sec = repoState.security_and_analysis || {};
   const ghasDesired = {
     secret_scanning: 'enabled',
     secret_scanning_push_protection: 'enabled',
     dependabot_security_updates: 'enabled',
   };
-  const ghasDrift = Object.entries(ghasDesired).filter(
-    ([k, v]) => (sec[k]?.status || 'disabled') !== v,
-  );
+  const ghasDrift = Object.entries(ghasDesired).filter(([k, v]) => {
+    if (sec[k] === undefined) return false; // field not visible to current token
+    return sec[k].status !== v;
+  });
   if (ghasDrift.length > 0) {
     driftCount++;
     console.log('▸ GitHub Advanced Security');


### PR DESCRIPTION
## Summary

`verify-gh-config.yml` runs under `GITHUB_TOKEN` which fundamentally cannot grant `administration: read`. As a result, `GET /repos/{slug}` omits `allow_auto_merge`, `delete_branch_on_merge`, and `security_and_analysis.*` from the response.

`apply-github-config.mjs` was treating those omissions as drift (`undefined !== true` → flagged), turning the workflow red on every run after PR #31. The workflow_dispatch run on `38a93e5c` confirmed this is reproducible:

```
~ allow_auto_merge:           - undefined / + true
~ delete_branch_on_merge:     - undefined / + true
~ secret_scanning:            - "disabled" / + "enabled"
~ secret_scanning_push_protection: - "disabled" / + "enabled"
~ dependabot_security_updates: - "disabled" / + "enabled"
```

Local runs with an admin PAT were unaffected.

## Fix

Treat `undefined` field reads as "not visible to current token, skip" rather than as drift in both the repo-settings and GHAS-toggle filters. The workflow still catches the drift classes that ARE visible under `GITHUB_TOKEN`: description, homepage, topics, rulesets, private vulnerability reporting — which is what it exists to catch in practice (UI-driven changes to topic lists / ruleset toggles).

Also added a header comment in `verify-gh-config.yml` documenting why `administration: read` isn't in the `permissions:` block (it can't be).

## Test plan

- [x] `node scripts/system/apply-github-config.mjs --verify` → 0 drift locally (unchanged; admin PAT still sees everything)
- [x] `actionlint .github/workflows/verify-gh-config.yml` → clean
- [x] Pre-push vitest + typecheck + format → all green
- [ ] After merge: trigger `verify-gh-config` via workflow_dispatch → exit 0
- [ ] Tomorrow 06:13 UTC: daily cron → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drift detection for repository configuration and GitHub Advanced Security settings to prevent false positives when using tokens with limited permissions. The system now correctly distinguishes between actual configuration changes and fields that are unavailable due to token scope limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->