### PR TITLE
docs(rulesets): document admin bypass actor (Task M skip-path validation)

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -12,6 +12,10 @@ repo. `gh api repos/kaelys-js/heron/rulesets` returns the live state;
 the daily `verify-gh-config` workflow asserts the JSON in this folder
 matches what's live.
 
+Bypass actors: the `Repository admin` role is configured as a bypass
+actor (mode: always) to allow `gh pr merge --admin` overrides. Tracked
+in `verify-gh-config` so any drift is caught the next morning.
+
 Two paths to changes:
 
 1. **Flip the repo public** (planned for the OSS launch milestone).


### PR DESCRIPTION
## Summary

Two-in-one PR:
1. **Real docs content**: documents the admin bypass actor on the main-branch ruleset (configured during PR #30's admin-merge unblock; not previously in the README).
2. **Behavioural validation fixture** for Task M (PR #58): proves the path-filter gating actually fires the skip paths on a PR that doesn't touch any filtered paths.

## What to watch in CI

This PR's diff is **a single .md file under .github/rulesets/** — nothing else. None of the path filters from Task M should match. Expected per-job behaviour:

| Required check | Expected on this PR |
|---|---|
| Tests / TS — typecheck + Vitest + coverage | **SKIP** (~30s skip-stub) |
| Tests / iOS — XCTest + XCUITest + Snapshot | **SKIP** (~30s skip-stub) |
| Tests / Lint + format (Python / Go / ...) | **SKIP** (~30s skip-stub) |
| Tests / Security audit | **SKIP** (~30s skip-stub) |
| CodeQL / Analyze (javascript-typescript) | **SKIP** (~30s resolve-gate only) |
| CodeQL / Analyze (python) | **SKIP** (~30s resolve-gate only) |
| CodeQL / Analyze (swift) | **SKIP** (~30s resolve-gate only) |
| dependency-review | runs (PR-metadata, not path-filtered) |
| OSSF Scorecard | runs |
| zizmor / Scan workflows | runs |
| DCO | runs |

**Pass criterion**: total CI wall time should be ~1-2 min instead of ~15-25 min for a full run. The 7 SKIP rows should show as completed in <30s each.

If any of the 7 SKIP rows actually runs full, Task M's filter is over-broad and I'll fix it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub ruleset configuration documentation with clarification on administrator bypass settings and override capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->