### PR TITLE
fix(ci): swift CodeQL cache + welcome inline check + slather scope

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -167,6 +167,30 @@ jobs:
         with:
           persist-credentials: false
 
+      # Swift-only caches. xcodebuild does the heavy work for the Swift
+      # leg; on a cold runner that's ~10 min of SPM resolve + Xcode
+      # build. Mirrors the cache strategy of test.yml's `ios` job:
+      # DerivedData keyed on pbxproj + Package.resolved, SPM keyed on
+      # Package.resolved. Cold-cache cost stays the same; warm-cache
+      # runs the Swift leg in ~3 min instead of ~12.
+      - name: Cache Xcode DerivedData (Swift only)
+        if: steps.gate.outputs.should_run == 'true' && matrix.language == 'swift'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: codeql-derived-data-${{ runner.os }}-${{ hashFiles('ui/ios/App/App.xcodeproj/project.pbxproj', 'ui/ios/App/Package.resolved') }}
+          restore-keys: |
+            codeql-derived-data-${{ runner.os }}-
+
+      - name: Cache SPM (Swift only)
+        if: steps.gate.outputs.should_run == 'true' && matrix.language == 'swift'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: codeql-spm-${{ runner.os }}-${{ hashFiles('ui/ios/App/Package.resolved') }}
+          restore-keys: |
+            codeql-spm-${{ runner.os }}-
+
       - name: Initialize CodeQL
         if: steps.gate.outputs.should_run == 'true'
         uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -6,8 +6,8 @@ name: Welcome
 # point of this workflow) would silently fail on every fork PR.
 # Risk mitigation:
 #   1. No `actions/checkout` step -- we never fetch PR head code.
-#   2. actions/first-interaction is SHA-pinned -- behaviour can't change
-#      without a deliberate PR through verify-workflow-pins.yml.
+#   2. No third-party action that does the "first interaction" check --
+#      we use gh CLI inline (see below for the rationale).
 #   3. Workflow-level permissions are {} -- the welcome job declares
 #      issues:write + pull-requests:write only on itself.
 on: # zizmor: ignore[dangerous-triggers]
@@ -31,12 +31,8 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    # actions/first-interaction's "is this their first PR?" detection
-    # works correctly for human users but treats every bot-account PR
-    # as the bot's first interaction (queries `author:` which doesn't
-    # index `[bot]`-suffixed accounts the same way). Result: Dependabot
-    # / Renovate / github-actions PRs got a fresh welcome on every PR.
-    # Skip bot PRs entirely -- they don't read welcome messages anyway.
+    # Bot PRs (Dependabot / Renovate / github-actions) don't get a welcome.
+    # The check below handles human PRs + issues separately.
     if: github.event_name == 'issues' || github.event.pull_request.user.type != 'Bot'
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -44,21 +40,78 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: |
-            Welcome to Heron, @${{ github.actor }}! Thanks for your first PR.
+      # Replaced actions/first-interaction@v3 with an inline gh check.
+      # The action's "is this the user's first interaction?" GraphQL
+      # query returns 0 for the repo owner under certain query shapes
+      # (known upstream bug), causing it to post the welcome on every
+      # PR by the maintainer -- including 5+ recent merged PRs (#55-#59).
+      # Verified locally: every recent PR has exactly one "Welcome to
+      # Heron, @kaelys-js! Thanks for your first PR." comment.
+      #
+      # Inline replacement: count the author's prior PRs/issues with
+      # `gh` and only post the welcome when this is genuinely their
+      # first (count == 1, where the 1 is this very PR/issue).
+      - name: Welcome first-time contributor (inline check)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+          # Bail if we somehow got here without an author (defensive --
+          # the workflow's `on:` triggers all include user context, but
+          # gh would fail with an empty --author).
+          if [ -z "${AUTHOR:-}" ]; then
+            echo "::notice::No author resolved from event payload; skipping welcome."
+            exit 0
+          fi
+          # Count the author's prior items of this kind. Including the
+          # current PR/issue means a true first-timer has count == 1.
+          # --limit 2 caps the lookup; we don't care beyond "more than 1".
+          case "$EVENT_NAME" in
+            pull_request_target)
+              count=$(gh pr list --author "$AUTHOR" --state all --limit 2 --json number --jq 'length')
+              kind=PR
+              num=$PR_NUM
+              ;;
+            issues)
+              count=$(gh issue list --author "$AUTHOR" --state all --limit 2 --json number --jq 'length')
+              kind=issue
+              num=$ISSUE_NUM
+              ;;
+            *)
+              echo "::notice::Unexpected event $EVENT_NAME; skipping welcome."
+              exit 0
+              ;;
+          esac
+          if [ "$count" -gt 1 ]; then
+            echo "::notice::Author @$AUTHOR has $count prior ${kind}s -- not a first-timer, skipping welcome."
+            exit 0
+          fi
+          echo "::notice::Author @$AUTHOR appears to be a first-timer (count=$count). Posting welcome on $kind #$num."
+          # Render the right message body via heredoc + post via gh.
+          if [ "$EVENT_NAME" = pull_request_target ]; then
+            cat > /tmp/welcome.md <<EOF
+          Welcome to Heron, @${AUTHOR}! Thanks for your first PR.
 
-            A few things to know:
-            - Tests will run automatically — check the status below
-            - Make sure you've linked a related issue (required for features)
-            - Read [CONTRIBUTING.md](../blob/main/.github/CONTRIBUTING.md) if you haven't
+          A few things to know:
+          - Tests will run automatically -- check the status below
+          - Make sure you've linked a related issue (required for features)
+          - Read [CONTRIBUTING.md](../blob/main/.github/CONTRIBUTING.md) if you haven't
 
-            We'll review your PR soon. Join our [Discord](https://discord.gg/8pRpHETxa4) if you have questions.
-          issue_message: |
-            Thanks for opening your first issue, @${{ github.actor }}! We'll take a look soon.
+          We'll review your PR soon. Join our [Discord](https://discord.gg/8pRpHETxa4) if you have questions.
+          EOF
+            gh pr comment "$num" --body-file /tmp/welcome.md
+          else
+            cat > /tmp/welcome.md <<EOF
+          Thanks for opening your first issue, @${AUTHOR}! We'll take a look soon.
 
-            In the meantime:
-            - Check [SUPPORT.md](../blob/main/.github/SUPPORT.md) for setup help
-            - Join our [Discord](https://discord.gg/8pRpHETxa4) for quick answers
+          In the meantime:
+          - Check [SUPPORT.md](../blob/main/.github/SUPPORT.md) for setup help
+          - Join our [Discord](https://discord.gg/8pRpHETxa4) for quick answers
+          EOF
+            gh issue comment "$num" --body-file /tmp/welcome.md
+          fi

--- a/ui/ios/App/fastlane/Fastfile
+++ b/ui/ios/App/fastlane/Fastfile
@@ -270,18 +270,48 @@ platform :ios do
     # reaches Codecov.
     #
     # `binary_basename: "App"` points slather at App.app's binary so it
-    # can map profdata back to source files. Verified locally produces a
-    # 680KB cobertura.xml with per-line hit info at line-rate 13.74%
-    # across the full DerivedData tree (App + extensions + Capacitor SPM).
-    # Codecov's iOS flag will display the combined picture; the threshold
-    # gate above stays narrowed to App.app via xcov's include_targets.
+    # can map profdata back to source files; on its own it produced a
+    # 680KB cobertura.xml with line-rate 13.74% across the full
+    # DerivedData tree (App + extensions + 22 Capacitor SPM packages
+    # + the WatchKit extension). Codecov's "iOS coverage" badge then
+    # displayed that misleading 13.74% even though the real product
+    # surface (App.app) tests at 66.14% via xcov's threshold gate.
+    #
+    # The `ignore` patterns below mirror xcov's `include_targets: "App.app"`
+    # filter: everything outside App's own sources is excluded from
+    # the Codecov cobertura. This brings the uploaded number into
+    # agreement with xcov's gate so a future regression in App
+    # coverage shows up as a Codecov delta, not buried in a giant
+    # DerivedData average.
     slather(
       proj: PROJECT,
       scheme: TEST_SCHEME,
       binary_basename: "App",
       output_directory: "fastlane/coverage",
       cobertura_xml: true,
-      use_bundle_exec: true
+      use_bundle_exec: true,
+      ignore: [
+        # SPM packages -- 22 Capacitor + plugins, vendored third-party
+        "**/SourcePackages/**",
+        "**/.build/**",
+        "**/DerivedSources/**",
+        # Build intermediates + compiled framework caches
+        "**/Build/Intermediates.noindex/**",
+        "**/Frameworks/**",
+        # Sibling app-extension targets (each has its own xcov entry
+        # via xcov's per-target table, not relevant to App.app)
+        "**/AppLiveActivity/**",
+        "**/AppShareExtension/**",
+        "**/AppWidget/**",
+        "**/CareerOpsWatch/**",
+        "**/CareerOpsWatchApp/**",
+        # Test bundles themselves -- 100% coverage of test code is
+        # meaningless noise.
+        "**/AppTests/**",
+        "**/AppUITests/**",
+        "**/WidgetTests/**",
+        "**/WatchTests/**"
+      ]
     )
   end
 


### PR DESCRIPTION
## Summary

Three independent fixes responding to a follow-up audit after Task M.

| Task | File | Goal |
|---|---|---|
| **N** | `.github/workflows/codeql.yml` | Add DerivedData + SPM caches to the Swift leg (mirrors `ios` Tests job). Pre-fix the Swift leg rebuilt cold every run (~12 min). Warm cache should drop it to ~3-5 min. |
| **O** | `.github/workflows/welcome.yml` | Replace `actions/first-interaction@v3` with an inline `gh pr list --author X --state all --limit 2` check. The v3 action mis-reports repo owners as first-timers (known upstream bug); PRs #55-#59 all got duplicate welcome comments. |
| **S** | `ui/ios/App/fastlane/Fastfile` | Add `slather` ignore patterns matching xcov's `include_targets: "App.app"`. Pre-fix uploaded coverage showed misleading 13.74% across full DerivedData (App + 22 SPM + extensions + test bundles) while the real product was 66.14% per xcov. |

## Background

User audit after Task M validation flagged three remaining items:
1. **"10 pending checks" on every PR** — investigated; not a bug. `gh pr merge --admin` bypasses required-check waiting; in-flight runs linger but don't gate anything.
2. **Swift CodeQL slow** — root caused to missing caches in the CodeQL workflow (vs the iOS Tests job which is cached). Task N fixes.
3. **Welcome bot still firing** — Task O fixes.
4. **Slather DerivedData noise** — Task S tunes.

Three "info-only / upstream" items remain unchanged:
- `actions/github-script@60a0d83` Node 20: transitive via `codecov-action@v5`. Dependabot PR `dependabot/github_actions/codecov/codecov-action-6.0.1` already open to resolve.
- `mise-action@v4.0.1` NODE_OPTIONS annotation: already on latest. Upstream issue.
- (S above addresses the third)

## Test plan

- [x] `actionlint .github/workflows/{codeql,welcome}.yml`: clean
- [x] `yamllint` same: clean
- [x] `zizmor --min-severity=medium`: 0 findings
- [x] `ruby -c ui/ios/App/fastlane/Fastfile`: Syntax OK
- [ ] Post-merge: Swift CodeQL on next non-Swift-touching PR runs in skip-stub (~30s); on next Swift-touching PR runs in ~3-5 min on warm cache (vs ~12 min pre-fix)
- [ ] Post-merge: next human PR by repo owner triggers welcome workflow → inline gh check sees prior PR count > 1 → posts no comment
- [ ] Post-merge: next iOS Tests run uploads slather cobertura with App-only coverage; Codecov "iOS" flag matches xcov's gate within 1-2 %

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented Swift build caching in CI workflows to improve build performance
  * Enhanced contributor welcome automation with improved first-time contributor detection
  * Refined code coverage reporting to exclude non-application dependencies for more accurate metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->