### PR TITLE
docs(ci): workflow header docstrings + step names + outcome logging (Phase 2)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,20 @@
 name: Dependency Review
+# Blocks PRs that introduce dependencies with high-severity GHSAs OR
+# non-permissive (GPL/AGPL/LGPL) licenses. Two layers of protection:
+#
+# 1. **License gate** -- positive allowlist (MIT / BSD / Apache-2 / ISC /
+#    MPL-2 / CC0 / Unlicense / 0BSD / Ruby / Python-2 / Zlib /
+#    BlueOak-1.0 / CC-BY-3/4 / WTFPL). Anything outside fails the PR.
+#    Heron ships under MIT + bundles Electron, so a GPL transitive would
+#    taint the binary's license.
+#
+# 2. **Vulnerability gate** -- fail-on-severity: high. Two transitive
+#    allowlist entries (jwt empty-key HMAC + highline GPL-OR-Ruby SPDX)
+#    are documented inline with rationale + revisit conditions.
+#
+# Fires on every pull_request against main; comments the dep diff on
+# the PR via comment-summary-in-pr: always. SARIF results also land in
+# the Code Scanning view for cross-referencing with CodeQL alerts.
 on:
   pull_request:
     branches: [main]
@@ -25,7 +41,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Dependency Review
+      - name: Dependency Review (GHSA + license gating)
+        id: review
         # G7 -- blocking again. The Dependency Graph must be enabled in
         # Settings → Security & Analysis (it's enabled by default for
         # public repos as of 2024). If a fork or restored repo somehow
@@ -91,3 +108,25 @@ jobs:
           # fastlane swaps in a different prompt library, drop this
           # allow-list line.
           allow-dependencies-licenses: pkg:gem/highline
+
+      # Visible outcome in the Actions summary tab. The dependency-review
+      # action posts a PR comment on every run; this step gives the
+      # maintainer a one-glance pass/fail in the Actions UI without
+      # opening the comment.
+      - name: Log outcome
+        if: always()
+        run: |
+          if [ "${{ steps.review.outcome }}" = "success" ]; then
+            echo "::notice::Dependency Review passed -- no high-severity GHSAs + all licenses on the allowlist."
+            echo "### ✅ Dependency Review passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Dependency Review failed -- check the PR comment for the GHSA / license violation."
+            {
+              echo "### ❌ Dependency Review failed"
+              echo ""
+              echo "See the PR comment for the specific dependency that triggered the block."
+              echo "If it's a license mismatch, decide between adding the license to the"
+              echo "allowlist or removing the dependency. If it's a GHSA, upgrade or add"
+              echo "to the inline allow-ghsas with rationale."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,17 @@
 name: Label PRs
 
+# Applies path-based labels to every PR so reviewers can spot the
+# blast radius at a glance. Rules live in `.github/labeler.yml`; this
+# workflow only invokes the third-party action.
+#
+# Fires on:
+#   - pull_request_target [opened, synchronize] -- relabels on every push
+#     to a PR branch so the labels track the current diff, not the first.
+#
+# What it produces:
+#   - 1-N labels on the PR (e.g. `area:ui`, `area:scripts`, `area:ci`).
+#   - No comments; the action is silent on success.
+#
 # pull_request_target is REQUIRED for this workflow -- actions/labeler
 # writes labels to the PR which needs the BASE branch's repo-write token.
 # Risk mitigation:
@@ -24,6 +36,7 @@ concurrency:
 
 jobs:
   label:
+    name: Apply path-based labels
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -35,6 +48,26 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+      - name: Apply labels from .github/labeler.yml
+        id: labeler
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log applied labels
+        if: always() && steps.labeler.outputs.all-labels != ''
+        env:
+          ALL_LABELS: ${{ steps.labeler.outputs.all-labels }}
+          NEW_LABELS: ${{ steps.labeler.outputs.new-labels }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          echo "::notice::Labeler applied {$ALL_LABELS} to PR #$PR_NUM (new: {$NEW_LABELS})."
+          {
+            echo "### 🏷️ Labels applied"
+            echo ""
+            echo "**All labels on this PR:** $ALL_LABELS"
+            if [ -n "$NEW_LABELS" ]; then
+              echo ""
+              echo "**Newly added this run:** $NEW_LABELS"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -92,8 +92,43 @@ jobs:
         run: node scripts/system/seed-lighthouse-user.mjs
 
       - name: Run Lighthouse CI
+        id: lhci
         uses: treosh/lighthouse-ci-action@512cc908a55bfb0ad231facca52adf3d3a651df4 # v12
         with:
           configPath: ./lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true
+
+      # Surface the scores in the Actions summary so the maintainer can
+      # see perf/a11y/SEO/best-practices at a glance without clicking
+      # through to the Lighthouse report URL. The action posts a PR
+      # comment with the same data; this step is the in-Actions mirror.
+      - name: Log Lighthouse scores
+        if: always() && hashFiles('.lighthouseci/manifest.json') != ''
+        # Heredoc with quoted EOF disables variable expansion at the
+        # shell level (so `${...}` inside is JS template literals, not
+        # bash). Avoids the shellcheck SC2016 false positive that the
+        # `node -e '...'` form trips.
+        run: |
+          set -euo pipefail
+          node <<'NODESCRIPT'
+            const fs = require("fs");
+            const manifest = JSON.parse(fs.readFileSync(".lighthouseci/manifest.json", "utf8"));
+            const lines = [];
+            lines.push("### 🚦 Lighthouse scores");
+            lines.push("");
+            lines.push("| URL | Performance | Accessibility | Best Practices | SEO |");
+            lines.push("|---|---|---|---|---|");
+            const fmt = (v) => v == null ? "?" : Math.round(v * 100);
+            for (const m of manifest) {
+              const lhr = JSON.parse(fs.readFileSync(m.jsonPath, "utf8"));
+              const c = lhr.categories;
+              lines.push(`| \`${m.url}\` | ${fmt(c.performance?.score)} | ${fmt(c.accessibility?.score)} | ${fmt(c["best-practices"]?.score)} | ${fmt(c.seo?.score)} |`);
+            }
+            lines.push("");
+            lines.push("Budgets in `lighthouserc.json`. Detailed report URLs in the PR comment.");
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+            // Compact notice for the run feed
+            const first = JSON.parse(fs.readFileSync(manifest[0].jsonPath, "utf8")).categories;
+            console.log(`::notice::Lighthouse scores: perf=${fmt(first.performance?.score)} a11y=${fmt(first.accessibility?.score)} bp=${fmt(first["best-practices"]?.score)} seo=${fmt(first.seo?.score)}`);
+          NODESCRIPT

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,10 +1,25 @@
 name: PR quality
 # G20 -- lightweight PR-title + size enforcement.
 #
-# Semantic PR title check is a 2s no-op when the title is already
-# Conventional Commits format (which Release Please depends on). The
-# size labeler adds XS/S/M/L/XL labels based on diff lines so reviewers
-# can budget time + we can spot mega-PRs early.
+# Two jobs, both fast (<5s each on the typical PR):
+#
+# 1. **Conventional Commits PR title** -- amannn/action-semantic-pull-request
+#    validates the title matches the Conventional Commits grammar
+#    (`<type>(<scope>): <subject>`). The 11 allowed types match
+#    release-please-config.json so the title becomes the squash-merge
+#    commit message that Release Please then categorises into
+#    CHANGELOG.md. `subjectPattern` enforces lowercase subject so
+#    `feat: Add retry helper` is rejected in favour of
+#    `feat(api): add retry helper`.
+#
+# 2. **PR size label** -- pascalgn/size-label-action tags every PR
+#    with `size/XS|S|M|L|XL` based on additions+deletions excluding
+#    auto-generated noise (lockfile, snapshots, icons, CHANGELOG).
+#    Bot PRs are skipped (Renovate / Dependabot self-size via their
+#    own labels). Helps reviewers budget time + flags mega-PRs early.
+#
+# Fires on every PR edit (opened/edited/synchronize/reopened) so a
+# title rename or force-push gets re-validated.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
@@ -29,7 +44,9 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - name: Validate Conventional Commits title
+        id: semantic
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -55,6 +72,24 @@ jobs:
             The PR-title subject (after the `type:` prefix) must start
             lowercase. e.g. `feat(api): add retry helper`, not
             `feat: Add retry helper`.
+
+      - name: Log title-check outcome
+        if: always()
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "${{ steps.semantic.outcome }}" = "success" ]; then
+            echo "::notice::Conventional Commits title check passed: \"$TITLE\""
+            {
+              echo "### ✅ Conventional Commits title check passed"
+              echo ""
+              echo "PR title: \`$TITLE\`"
+              echo ""
+              echo "This title becomes the squash-merge commit subject + feeds Release Please into CHANGELOG.md."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::PR title \"$TITLE\" failed the Conventional Commits check. Rename to match \`<type>(<scope>): <lowercase subject>\`."
+          fi
 
   size-label:
     name: PR size label

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ permissions:
 
 jobs:
   release-please:
+    name: Release Please (semver + CHANGELOG + tag)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -58,7 +59,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+      - name: Run release-please
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: rp
         with:
           config-file: release-please-config.json
@@ -68,6 +70,33 @@ jobs:
           # the workflow_call below, which inherits the same run context
           # without needing a PAT.
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Visible outcome in the Actions summary tab. Release Please's own
+      # output is opaque (just `release_created: true|false`); this step
+      # makes the result legible at a glance + tells the maintainer what
+      # to expect next (the build-natives workflow_call to native-release.yml).
+      - name: Log release-please outcome
+        if: always()
+        env:
+          RELEASE_CREATED: ${{ steps.rp.outputs.release_created }}
+          TAG_NAME: ${{ steps.rp.outputs.tag_name }}
+          VERSION: ${{ steps.rp.outputs.major }}.${{ steps.rp.outputs.minor }}.${{ steps.rp.outputs.patch }}
+        run: |
+          if [ "$RELEASE_CREATED" = "true" ]; then
+            echo "::notice::Released $TAG_NAME (v$VERSION). native-release.yml fires next."
+            {
+              echo "### 🚀 Release cut: $TAG_NAME"
+              echo ""
+              echo "Version: \`v$VERSION\`"
+              echo ""
+              echo "GitHub Release created + tag pushed. \`native-release.yml\` now builds"
+              echo "DMG / .exe / .AppImage / iOS TestFlight artefacts and attaches them"
+              echo "to the Release."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::notice::No release this run (no bump-worthy commits since last tag, or release PR not yet merged)."
+            echo "### 🟦 No release cut this run" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # When Release Please cuts a real release (i.e. the release PR was just
   # merged), kick off the cross-platform build. workflow_call within the

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,25 @@
 name: 'Close stale issues and PRs'
+# Weekly housekeeping for inactive issues + PRs. Cadence:
+#
+# **Issues**: stale at 60 days inactivity, closed 14 days later (so
+# 74 days total to auto-close).
+# **PRs**:    stale at 30 days inactivity, closed 14 days later (so
+# 44 days total to auto-close).
+#
+# Stale + closed states post a friendly comment explaining how to
+# revive (rebase + comment). The pr-bots workflow's stale-pinger job
+# pings 7 days before close as an extra nudge.
+#
+# Exempt labels:
+#   - `pinned`     (manual override -- "keep this regardless")
+#   - `security`   (security-sensitive work shouldn't bit-rot silently)
+#   - `roadmap`    (long-running planning issues)
+#   - `hired`      (success stories from i-got-hired.yml -- the social
+#                   proof Hall of Fame; HP24)
+#
+# Fires:
+#   - Mondays 06:00 UTC (off-peak)
+#   - workflow_dispatch (manual sweep)
 on:
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 6am UTC
@@ -13,6 +34,7 @@ concurrency:
 
 jobs:
   stale:
+    name: Auto-stale + auto-close housekeeping
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/testflight-keepalive.yml
+++ b/.github/workflows/testflight-keepalive.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   rebuild:
+    name: Push keepalive tag (triggers native-release.yml)
     # Tagging doesn't need macOS -- pick the cheap runner. The actual
     # build runs on macOS via native-release.yml after the tag push.
     runs-on: ubuntu-latest
@@ -36,13 +37,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # zizmor/artipacked -- don't persist token in .git/config; we
           # re-inject it inline in the push step below.
           persist-credentials: false
           fetch-depth: 0
-      - name: Bump build number + tag
+      - name: Bump build number + push keepalive tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -59,4 +61,15 @@ jobs:
           # this single command and never lands in .git/config.
           HOSTLESS_URL="${SERVER_URL#https://}"
           git push "https://x-access-token:${GH_TOKEN}@${HOSTLESS_URL}/${REPO}.git" "$NEW_TAG"
+          # Visible outcome -- the tag push triggers native-release.yml
+          # which runs build-ios on macOS-15 and pushes to TestFlight.
+          echo "::notice::Pushed keepalive tag $NEW_TAG. native-release.yml will now build + upload to TestFlight."
+          {
+            echo "### 📦 Keepalive tag pushed: $NEW_TAG"
+            echo ""
+            echo "Base version: \`$CURRENT\`"
+            echo "Build date:   \`$DATE_TAG\`"
+            echo ""
+            echo "Watch \`native-release.yml\` for the iOS build + TestFlight upload."
+          } >> "$GITHUB_STEP_SUMMARY"
       # The tag push triggers native-release.yml which runs build-ios.


### PR DESCRIPTION
## Summary

Phase 2 of 3-phase workflow audit. 7 workflows touched. Pure naming/docs/logging discipline — no logic changes, no required-check renames.

### Header docstrings expanded
- `labeler.yml`, `dependency-review.yml`, `pr-quality.yml`, `stale.yml`

### Outcome logging added
- `release.yml`, `labeler.yml`, `lighthouse.yml`, `dependency-review.yml`, `pr-quality.yml`, `testflight-keepalive.yml`

### Step name nits
- 5 anonymous `- uses:` steps got explicit `name:` for cleaner Actions UI

## Test plan

- [x] actionlint, yamllint, zizmor: clean across all 7 files
- [x] verify-no-slop: clean
- [ ] After merge: next Dependency Review fires the new ✅/❌ summary
- [ ] After merge: next Lighthouse run posts the per-URL score table
- [ ] After merge: next stale.yml run shows new job name "Auto-stale + auto-close housekeeping"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflows with improved logging and documentation
  * Added explicit step identification and outcome reporting across multiple CI/CD pipelines
  * Improved visibility into dependency reviews, code quality checks, and release processes
  * Updated workflow documentation and step naming for better clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->