### PR TITLE
ci: verify-workflow-quality script + 16 workflow naming nits (Phase 3)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,6 +29,11 @@ concurrency:
 
 jobs:
   dependency-review:
+    # `name:` matches the key so the branch-protection required-check
+    # context (`Dependency Review / dependency-review`) stays stable.
+    # Renaming this string would break the rule until the ruleset SSOT
+    # is also updated.
+    name: dependency-review
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   lychee:
+    name: Link check (lychee)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -148,7 +148,8 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -162,7 +163,8 @@ jobs:
       # repo content (.mise.toml, lockfiles) that's only mutable via
       # merged PRs that already passed PR CI, so a malicious PR can't
       # poison the release-time cache without first getting code merged.
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4 # zizmor: ignore[cache-poisoning]
+      - name: Setup mise (Node + pnpm from .mise.toml)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4 # zizmor: ignore[cache-poisoning]
         with:
           experimental: true
           cache: true
@@ -175,7 +177,8 @@ jobs:
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
       # zizmor: ignore[cache-poisoning] -- see jdx/mise-action note above.
       # pnpm-lock.yaml is integrity-verified at install time.
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -187,7 +190,8 @@ jobs:
       # zizmor: ignore[cache-poisoning] -- electron downloads are
       # SHA256-verified by electron-builder against the version pinned
       # in ui/electron/package.json (which keys the cache).
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
+      - name: Cache electron-builder downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: |
             ~/.cache/electron
@@ -331,7 +335,8 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -340,7 +345,8 @@ jobs:
       # zizmor/cache-poisoning -- same release-only-trigger rationale
       # as the build-desktop job above (this workflow runs only on
       # maintainer-pushed tags / workflow_call from release.yml).
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4 # zizmor: ignore[cache-poisoning]
+      - name: Setup mise (Node + pnpm + Ruby from .mise.toml)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4 # zizmor: ignore[cache-poisoning]
         with:
           experimental: true
           cache: true
@@ -352,7 +358,8 @@ jobs:
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
       # zizmor: ignore[cache-poisoning] -- pnpm integrity-verifies from
       # the lockfile that keys this cache; see build-desktop job notes.
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -364,7 +371,8 @@ jobs:
       # zizmor: ignore[cache-poisoning] -- SPM dependencies are SHA-
       # pinned in Package.resolved (which keys the cache); xcodebuild
       # re-verifies on restore.
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
+      - name: Cache Xcode DerivedData + SPM packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
@@ -378,7 +386,8 @@ jobs:
       # zizmor: ignore[cache-poisoning] -- bundler verifies gems
       # against the Gemfile.lock checksums; the lockfile is committed
       # and changes only via PR.
-      - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0 # zizmor: ignore[cache-poisoning]
+      - name: Setup Ruby + bundler-cache (Fastlane gems)
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0 # zizmor: ignore[cache-poisoning]
         with:
           bundler-cache: true
           working-directory: ui/ios/App

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -104,7 +104,8 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
+      - name: Apply size labels (XS / S / M / L / XL)
+        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Customised thresholds -- Heron PRs skew larger than the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Avoid overlapping releases.
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
 # Top-level is read-only. release-please needs writes to create
 # branches + PRs + tags + comment on issues; declared inside the job.
 permissions:
   contents: read
+
+# Avoid overlapping releases.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release-please:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   sbom:
+    name: Generate SBOM (CycloneDX) + attest
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -46,7 +46,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+      - name: Run actions/stale (close inactive issues + PRs)
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -838,9 +838,35 @@ jobs:
       # cache enabled). No per-tool curl / pip / gem / apt install needed
       # -- fresh-clone reproducibility is the whole point of mise.
 
+      # `validate:workflows` needs js-yaml from node_modules. Install
+      # only what's needed (root deps, not the ui/electron workspaces)
+      # so the install is fast on warm cache. Same `pnpm-` cache key as
+      # the ts job so the pnpm store cross-pollinates.
+      - name: Cache pnpm store (format job)
+        if: needs.changes.outputs.format == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.local/share/pnpm/store/v3
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+      - name: Install root node_modules (for validate:workflows)
+        if: needs.changes.outputs.format == 'true'
+        # --filter=. installs only the root manifest's deps, skipping
+        # ui/ui-electron workspaces. Keeps the format job lean.
+        run: pnpm install --filter=. --frozen-lockfile
+
       - name: actionlint .github/workflows/*.yml
         if: needs.changes.outputs.format == 'true'
         run: actionlint -color
+
+      # Naming / docstring / structure discipline across workflows.
+      # Complements actionlint (syntax), zizmor (security), and
+      # verify-workflow-pins (third-party SHA pins). See
+      # scripts/system/verify-workflow-quality.mjs for the 7 rules.
+      - name: Workflow quality (header / permissions / concurrency / names / order)
+        if: needs.changes.outputs.format == 'true'
+        run: pnpm validate:workflows
 
       - name: ruff format --check
         if: needs.changes.outputs.format == 'true'

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   welcome:
+    name: Welcome first-time contributors
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "validate:plists": "python3 scripts/system/validate-plists.py",
     "validate:tiny-configs": "node scripts/system/validate-tiny-configs.mjs",
     "validate:version-sync": "node scripts/system/validate-version-sync.mjs",
+    "validate:workflows": "node scripts/system/verify-workflow-quality.mjs",
     "validate:xml": "bash scripts/system/validate-xml.sh",
     "verify:comment-style": "node scripts/system/verify-comment-style.mjs",
     "verify:comment-style:test": "node scripts/system/verify-comment-style.test.mjs",

--- a/scripts/system/verify-workflow-quality.mjs
+++ b/scripts/system/verify-workflow-quality.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+// verify-workflow-quality.mjs -- enforce naming + docstring + structure
+// discipline across .github/workflows/*.yml.
+//
+// Complements (does NOT duplicate):
+//   - actionlint  -- syntax + GH-Actions-specific lints
+//   - zizmor      -- security analysis
+//   - verify-workflow-pins.yml -- third-party action SHA pinning
+//
+// Seven gates:
+//   1. Top-of-file `#` block comment within the first 10 lines explaining
+//      the workflow's purpose + triggers (skip if file is shorter than 5 lines)
+//   2. Explicit top-level `permissions:` block (even `{}`)
+//   3. PR-triggered workflows MUST have a top-level `concurrency:` block
+//      (cancel-in-progress on PR ref so push-spam doesn't burn minutes)
+//   4. Every `name:` field is non-empty and >= 5 chars
+//   5. Every job has a `name:` field (cleaner Actions UI)
+//   6. Every step has a `name:` field
+//   7. Conventional file ordering: name, on, permissions, concurrency, jobs
+//
+// Exit codes:
+//   0 = clean
+//   1 = at least one offender
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOWS_DIR = join(ROOT, '.github', 'workflows');
+
+// ── Tunables ──────────────────────────────────────────────────────
+
+export const HEADER_COMMENT_WITHIN_LINES = 10;
+export const MIN_NAME_LENGTH = 5;
+export const EXPECTED_ORDER = ['name', 'on', 'permissions', 'concurrency', 'jobs'];
+
+// ── Scanners (exported for tests) ────────────────────────────────
+
+/** Rule 1: top-of-file `#` comment must appear in the first
+ *  HEADER_COMMENT_WITHIN_LINES lines. The first comment line should
+ *  follow the workflow `name:` directive (which is mandatory).
+ *  Returns [] or [{rule: 'header', line: 1, msg}]. */
+export function checkHeaderComment(body) {
+  const lines = body.split('\n');
+  if (lines.length < 5) return []; // skip very short files
+  // Look for a `#` line within the first HEADER_COMMENT_WITHIN_LINES lines.
+  // YAML comments start with `#` (must be at column 0 or after whitespace,
+  // but for header docs we expect column 0).
+  for (let i = 0; i < Math.min(HEADER_COMMENT_WITHIN_LINES, lines.length); i++) {
+    if (/^\s*#\s/.test(lines[i])) return [];
+  }
+  return [
+    {
+      rule: 'header',
+      line: 1,
+      msg: `No header comment in the first ${HEADER_COMMENT_WITHIN_LINES} lines. Add a top-of-file \`# ...\` block explaining purpose + triggers.`,
+    },
+  ];
+}
+
+/** Rule 2: top-level `permissions:` is present (even `permissions: {}`). */
+export function checkPermissions(parsed) {
+  if (!Object.prototype.hasOwnProperty.call(parsed, 'permissions')) {
+    return [
+      {
+        rule: 'permissions',
+        line: 1,
+        msg: 'Missing top-level `permissions:` block. Default to `{}` and elevate per-job.',
+      },
+    ];
+  }
+  return [];
+}
+
+/** Rule 3: pull_request / pull_request_target triggers require
+ *  top-level `concurrency:` with `cancel-in-progress`. */
+export function checkConcurrency(parsed) {
+  const on = parsed.on;
+  if (!on) return [];
+  const triggers = typeof on === 'string' ? [on] : Object.keys(on);
+  const isPrTriggered = triggers.some((t) => ['pull_request', 'pull_request_target'].includes(t));
+  if (!isPrTriggered) return [];
+  if (!parsed.concurrency) {
+    return [
+      {
+        rule: 'concurrency',
+        line: 1,
+        msg: 'PR-triggered workflow missing `concurrency:` block. Add one with `cancel-in-progress: true` so push-spam to a PR cancels stale runs.',
+      },
+    ];
+  }
+  return [];
+}
+
+/** Walk the parsed workflow's name fields:
+ *    - workflow.name
+ *    - each job's name (if declared; a job whose key is the name is ok)
+ *    - each step's name
+ *  Returns offenders: { rule: 'name', context, msg }. */
+export function checkNames(parsed) {
+  const offenders = [];
+  // Workflow-level name
+  if (parsed.name === undefined) {
+    offenders.push({
+      rule: 'name',
+      context: 'workflow',
+      msg: 'Workflow missing top-level `name:` field.',
+    });
+  } else if (typeof parsed.name === 'string' && parsed.name.trim().length < MIN_NAME_LENGTH) {
+    offenders.push({
+      rule: 'name',
+      context: 'workflow',
+      msg: `Workflow name "${parsed.name}" is shorter than ${MIN_NAME_LENGTH} chars.`,
+    });
+  }
+  // Jobs + steps
+  const jobs = parsed.jobs ?? {};
+  for (const [jobKey, job] of Object.entries(jobs)) {
+    if (typeof job !== 'object' || job === null) continue;
+    // Skip reusable workflow-call jobs (they have `uses:` instead of steps).
+    if (typeof job.uses === 'string') continue;
+    if (!job.name) {
+      offenders.push({
+        rule: 'name',
+        context: `job:${jobKey}`,
+        msg: `Job \`${jobKey}\` missing \`name:\` field. Job names show up in branch-protection required-checks; explicit names are clearer than the key.`,
+      });
+    } else if (job.name.trim().length < MIN_NAME_LENGTH) {
+      offenders.push({
+        rule: 'name',
+        context: `job:${jobKey}`,
+        msg: `Job \`${jobKey}\` name "${job.name}" is shorter than ${MIN_NAME_LENGTH} chars.`,
+      });
+    }
+    const steps = job.steps ?? [];
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      if (!step || typeof step !== 'object') continue;
+      if (!step.name) {
+        // Identify the step in the offender by either `uses:` or `run:` snippet
+        const ident = step.uses
+          ? `uses: ${step.uses}`
+          : step.run
+            ? `run: ${String(step.run).split('\n')[0].slice(0, 60)}...`
+            : '(unknown)';
+        offenders.push({
+          rule: 'name',
+          context: `job:${jobKey}/steps[${i}]`,
+          msg: `Step #${i} in job \`${jobKey}\` missing \`name:\` field (${ident}).`,
+        });
+      } else if (step.name.trim().length < MIN_NAME_LENGTH) {
+        offenders.push({
+          rule: 'name',
+          context: `job:${jobKey}/steps[${i}]`,
+          msg: `Step #${i} in job \`${jobKey}\` name "${step.name}" is shorter than ${MIN_NAME_LENGTH} chars.`,
+        });
+      }
+    }
+  }
+  return offenders;
+}
+
+/** Rule 7: top-level keys appear in EXPECTED_ORDER. Keys not in the list
+ *  are tolerated (some workflows declare `defaults:`, `env:`, `run-name:`
+ *  etc.); we only check that the keys that DO appear from EXPECTED_ORDER
+ *  appear in that relative order. */
+export function checkOrdering(body) {
+  // Use a regex over the raw text to find the LINE of each top-level key.
+  // (The YAML parser doesn't preserve source ordering reliably across versions.)
+  const lines = body.split('\n');
+  const positions = {};
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = /^([a-z][a-z_-]*):/.exec(line);
+    if (m && EXPECTED_ORDER.includes(m[1])) {
+      if (positions[m[1]] === undefined) positions[m[1]] = i + 1;
+    }
+  }
+  // Verify the keys that ARE present appear in EXPECTED_ORDER.
+  const present = EXPECTED_ORDER.filter((k) => positions[k] !== undefined);
+  const offenders = [];
+  for (let i = 1; i < present.length; i++) {
+    if (positions[present[i]] < positions[present[i - 1]]) {
+      offenders.push({
+        rule: 'ordering',
+        line: positions[present[i]],
+        msg: `Top-level key \`${present[i]}\` (line ${positions[present[i]]}) appears before \`${present[i - 1]}\` (line ${positions[present[i - 1]]}). Convention is: ${EXPECTED_ORDER.join(' → ')}.`,
+      });
+    }
+  }
+  return offenders;
+}
+
+/** Run all 7 rules on a single workflow file. */
+export function scanWorkflow(path, body) {
+  const offenders = [];
+  // Parse YAML once.
+  let parsed;
+  try {
+    parsed = yaml.load(body);
+  } catch (e) {
+    return [{ rule: 'parse', line: 1, msg: `YAML parse error: ${e.message}` }];
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return [{ rule: 'parse', line: 1, msg: 'YAML root is not an object.' }];
+  }
+  offenders.push(...checkHeaderComment(body));
+  offenders.push(...checkPermissions(parsed));
+  offenders.push(...checkConcurrency(parsed));
+  offenders.push(...checkNames(parsed));
+  offenders.push(...checkOrdering(body));
+  return offenders;
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────
+
+function main() {
+  const files = readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith('.yml'));
+  let totalOffenders = 0;
+  const fileFails = [];
+  for (const f of files.sort()) {
+    const path = join(WORKFLOWS_DIR, f);
+    const body = readFileSync(path, 'utf8');
+    const offenders = scanWorkflow(path, body);
+    if (offenders.length > 0) {
+      fileFails.push({ file: f, offenders });
+      totalOffenders += offenders.length;
+    }
+  }
+  if (totalOffenders === 0) {
+    console.log(`OK verify-workflow-quality - ${files.length} workflow(s) scanned, 0 offenders.`);
+    process.exit(0);
+  }
+  console.error(
+    `FAIL verify-workflow-quality - ${totalOffenders} offender(s) across ${fileFails.length} file(s):`,
+  );
+  console.error('');
+  for (const { file, offenders } of fileFails) {
+    console.error(`  .github/workflows/${file}:`);
+    for (const o of offenders) {
+      const loc = o.line !== undefined ? `line ${o.line}` : o.context || '?';
+      console.error(`    [${o.rule}] ${loc}: ${o.msg}`);
+    }
+    console.error('');
+  }
+  console.error(`Rules: header (top-of-file # comment), permissions (top-level block),`);
+  console.error(
+    `       concurrency (PR-triggered workflows), name (workflow/job/step >= ${MIN_NAME_LENGTH} chars),`,
+  );
+  console.error(`       ordering (${EXPECTED_ORDER.join(' → ')}).`);
+  process.exit(1);
+}
+
+// Only run main() when invoked as a script, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Phase 3 of 3-phase workflow audit. Adds an automated check that prevents the naming / docstring / structure issues from drifting back in.

### New: `scripts/system/verify-workflow-quality.mjs`

Seven rules — complements actionlint (syntax), zizmor (security), verify-workflow-pins (SHA pins):
1. Top-of-file `#` comment within first 10 lines
2. Explicit top-level `permissions:` block (even `{}`)
3. PR-triggered workflows have `concurrency:` block
4. Every `name:` field non-empty + ≥5 chars
5. Every job has a `name:` field
6. Every step has a `name:` field
7. Conventional file ordering: `name` → `on` → `permissions` → `concurrency` → `jobs`

Wired into the `format` job in `test.yml` as `pnpm validate:workflows` (gated by the path-filter; reuses pnpm cache from `ts` job).

### Naming fixes (27 workflows → 0 offenders)

10 files touched to clear the initial offender list:
- `dependency-review.yml`, `link-check.yml`, `sbom.yml`, `welcome.yml`, `stale.yml`, `pr-quality.yml`, `release.yml`, `native-release.yml` (×9 step renames)

The `dependency-review` job gets `name: dependency-review` matching the key (preserves the required-check context name; no branch-protection breakage).

### Test plan

- [x] `node scripts/system/verify-workflow-quality.mjs`: 27 workflows, 0 offenders
- [x] `actionlint`, `yamllint`, `zizmor`: clean across all touched files
- [ ] After merge: future workflow PRs that introduce naming regressions get caught by the format job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflows with explicit naming for jobs and steps to improve clarity and maintain stable status check contexts in branch protection rules.
  * Added automated workflow quality validation to enforce consistent naming conventions, required configuration blocks, and proper key ordering across all automation pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->