### PR TITLE
feat(ci): per-push PR CI summary comment + description marker (PR B of 3)

### DIFF
--- a/.github/workflows/pr-ci-summary.yml
+++ b/.github/workflows/pr-ci-summary.yml
@@ -1,0 +1,192 @@
+name: PR CI summary
+
+# After a Tests workflow run completes on a PR push, post a fresh
+# comment AND refresh the PR description's CI-STATUS marker block.
+# Reviewers can see at a glance whether the latest revision passed
+# without scrolling through historical CI comments.
+#
+# How it works:
+#   1. Trigger on `workflow_run.completed` for the Tests workflow.
+#   2. Filter: only when the source run was a pull_request event.
+#      The workflow_run payload exposes `pull_requests[]` for same-repo
+#      PRs; fork PRs fall back to a `gh pr list --head` lookup.
+#   3. Compose a comment summarising pass/fail + run link + first
+#      failing job's name on failure. Post via `gh pr comment`.
+#   4. Update the PR description: find the
+#      `<!-- CI-STATUS-MARKER-START -->...<!-- CI-STATUS-MARKER-END -->`
+#      block and replace its content with the latest summary. If
+#      the marker isn't present, prepend it to the body.
+#
+# Permissions:
+#   `workflow_run` events have a reduced trust model -- secrets
+#   inherit, but pull_request_target's branch isolation doesn't apply.
+#   This workflow declares the minimum: pull-requests:write to comment
+#   and edit the body; actions:read to query the source run; no
+#   contents (we don't read repo files).
+#
+# Why a separate workflow vs extending pr-bots.yml:
+#   pr-bots.yml is `pull_request_target` triggered (PR open / label /
+#   review). The Tests workflow runs OVER THE COURSE of a PR push and
+#   finishes async; only `workflow_run` lets us hook the completion.
+#   Keeping the two patterns separate keeps each workflow's trigger
+#   surface clean + auditable.
+
+on: # zizmor: ignore[dangerous-triggers]
+  # SAFETY: workflow_run inherits write secrets, but this workflow's
+  # surface is narrow + checked:
+  #   1. No actions/checkout step -- PR head code never lands on the
+  #      runner. We only read PR metadata via the gh CLI.
+  #   2. No shell-evaluation of untrusted strings -- every gh pr
+  #      comment / gh pr edit uses --body-file with content composed
+  #      by the workflow itself (run number, sha, conclusion strings),
+  #      never interpolated PR data.
+  #   3. Permissions are minimum-necessary: actions:read (query the
+  #      source run) + pull-requests:write (comment + edit body). No
+  #      contents, no id-token, no packages.
+  # The conventional misuse of workflow_run is checking out the PR
+  # head + running its code with elevated trust -- we do neither.
+  workflow_run:
+    workflows: ['Tests']
+    types: [completed]
+
+# Workflow-level default = nothing. Per-job permissions below.
+permissions: {}
+
+concurrency:
+  group: pr-ci-summary-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  summarise:
+    name: Post PR comment + refresh description marker
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read # query the source workflow_run + its jobs
+      pull-requests: write # comment + edit body
+    # Only act on real PR-triggered runs that completed (skip cancelled
+    # / skipped / in-progress). Both success + failure get a comment;
+    # the comment template branches on conclusion below.
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Resolve PR number + compose comment
+        id: compose
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+
+          # 1. Resolve PR number.
+          # `pull_requests` is non-empty for same-repo PRs; for fork PRs
+          # it's empty and we fall back to a head-branch lookup.
+          PR_NUM=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH" || true)
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(gh pr list --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "$PR_NUM" ]; then
+            echo "::notice::No PR found for head branch \`$HEAD_BRANCH\`. Nothing to comment on."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+          # 2. Compose the marker block + the standalone comment.
+          if [ "$CONCLUSION" = "success" ]; then
+            ICON="✅"
+            STATUS="passed"
+          else
+            ICON="❌"
+            STATUS="failed"
+          fi
+
+          # Marker block (prepended/replaced in PR description body).
+          # Keep the delimiters EXACT -- the replacer below greps for
+          # the literal strings.
+          {
+            echo "<!-- CI-STATUS-MARKER-START -->"
+            echo "> **Latest CI**: $ICON $STATUS on \`$SHORT_SHA\` (run [#$RUN_NUMBER]($RUN_URL))"
+            echo "<!-- CI-STATUS-MARKER-END -->"
+          } > /tmp/marker.md
+
+          # Standalone comment -- richer than the marker.
+          if [ "$CONCLUSION" = "success" ]; then
+            cat > /tmp/comment.md <<EOF
+          $ICON **CI passed** on commit \`$SHORT_SHA\` (run [#$RUN_NUMBER]($RUN_URL)).
+
+          All required checks completed successfully.
+
+          _Posted by .github/workflows/pr-ci-summary.yml — fires after each push when the Tests workflow completes._
+          EOF
+          else
+            # Failure path: list the failed jobs + grab the first
+            # error annotation as a teaser.
+            FAILED_JOBS=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID/jobs" \
+              --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+            FAILED_JOBS="${FAILED_JOBS:-<unknown>}"
+            cat > /tmp/comment.md <<EOF
+          $ICON **CI failed** on commit \`$SHORT_SHA\` (run [#$RUN_NUMBER]($RUN_URL)).
+
+          Failed jobs: \`$FAILED_JOBS\`
+
+          Open the [run]($RUN_URL) for the full log + failing-step annotations.
+
+          _Posted by .github/workflows/pr-ci-summary.yml — fires after each push when the Tests workflow completes._
+          EOF
+          fi
+
+      - name: Post comment + update PR body
+        if: steps.compose.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.compose.outputs.pr_num }}
+          SHORT_SHA: ${{ steps.compose.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+
+          # 1. Post the standalone comment.
+          gh pr comment "$PR_NUM" --body-file /tmp/comment.md
+          echo "::notice::Posted CI summary comment on PR #$PR_NUM (sha $SHORT_SHA)."
+
+          # 2. Update PR description marker block.
+          # Fetch the current body, replace (or prepend) the marker.
+          BODY=$(gh pr view "$PR_NUM" --json body --jq '.body // ""')
+          MARKER_NEW=$(cat /tmp/marker.md)
+          if printf '%s' "$BODY" | grep -q '<!-- CI-STATUS-MARKER-START -->'; then
+            # Replace existing marker block in place.
+            UPDATED=$(printf '%s' "$BODY" | perl -0777 -pe '
+              my $new = `cat /tmp/marker.md`;
+              chomp $new;
+              s/<!-- CI-STATUS-MARKER-START -->.*?<!-- CI-STATUS-MARKER-END -->/$new/gs;
+            ')
+          else
+            # Prepend marker block, with a blank line separating from existing body.
+            UPDATED=$(printf '%s\n\n%s' "$MARKER_NEW" "$BODY")
+          fi
+          # gh pr edit --body reads from stdin via the special `-` arg.
+          printf '%s' "$UPDATED" | gh pr edit "$PR_NUM" --body-file -
+          echo "::notice::Refreshed CI-STATUS marker in PR #$PR_NUM description."
+
+          # 3. Step summary for the action's own run.
+          {
+            echo "### Posted CI summary to PR #$PR_NUM"
+            echo ""
+            cat /tmp/marker.md
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Second of three PRs from the PR-lifecycle audit. **Adds the per-push "new comment + description summary" gate the user asked for.**

| Behaviour | Trigger |
|---|---|
| New comment per push | After each PR push, when Tests workflow completes (success OR failure). |
| Description marker refresh | Same trigger; replaces the `<!-- CI-STATUS-MARKER -->` block in PR body in place. First push prepends; later pushes REPLACE. |

Comment format on **success**:
> ✅ **CI passed** on commit `abc1234` (run [#42](link))
> All required checks completed successfully.

Comment format on **failure**:
> ❌ **CI failed** on commit `abc1234` (run [#42](link))
> Failed jobs: `Tests / TS — typecheck`, `Tests / iOS — XCTest`
> Open the [run](link) for the full log + failing-step annotations.

Description marker (prepended on first push, replaced in place after):
```
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ passed on `abc1234` (run [#42](link))
<!-- CI-STATUS-MARKER-END -->
```

## Safety analysis

`workflow_run` is a high-risk trigger when misused (the classic vector is checking out the PR head + running its code with elevated trust). This workflow does neither:
- No `actions/checkout` step
- No shell-evaluation of untrusted strings
- Permissions: `actions: read` + `pull-requests: write` only

Zizmor confirms the narrow surface (1 ignore for `dangerous-triggers` rule with inline rationale).

## Test plan

- [x] `actionlint`, `yamllint` -> clean
- [x] `zizmor --min-severity=medium` -> 0 findings (1 documented ignore)
- [x] `verify-workflow-quality` -> 28 workflows, 0 offenders
- [ ] After merge: push to a PR, observe new comment + marker block on the next Tests completion
- [ ] After merge: push a second time, observe the comment APPENDS (new audit row) but the marker REPLACES (single in-place summary)

## Notes for reviewers

PR C is the last in this audit batch: `feat:` requires issue link, `<type>!:` requires `BREAKING CHANGE:` body, missing-tests soft-warning. Follows this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added automatic PR comments summarizing CI test results and status
* Automated updates to PR descriptions with CI status information and commit details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->