### PR TITLE
fix(ci): drop push-ruleset rules unsupported on free+public repos

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -65,42 +65,6 @@
       "parameters": {
         "severity": "errors"
       }
-    },
-    {
-      "type": "commit_message_pattern",
-      "parameters": {
-        "name": "Conventional Commits",
-        "negate": false,
-        "operator": "regex",
-        "pattern": "^((Merge|Revert|fixup!|squash!|chore\\(main\\): release)|(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\\([a-z0-9_-]+\\))?!?: .{1,72})"
-      }
-    },
-    {
-      "type": "max_file_size",
-      "parameters": {
-        "max_file_size": 5
-      }
-    },
-    {
-      "type": "max_file_path_length",
-      "parameters": {
-        "max_file_path_length": 255
-      }
-    },
-    {
-      "type": "file_extension_restriction",
-      "parameters": {
-        "restricted_file_extensions": [
-          ".exe",
-          ".dll",
-          ".so",
-          ".dylib",
-          ".pem",
-          ".key",
-          ".p8",
-          ".p12"
-        ]
-      }
     }
   ],
   "bypass_actors": [


### PR DESCRIPTION
## Summary

Rollback of the 4 push-target rules added to `main.json` in PR #69. Those rules (`commit_message_pattern`, `max_file_size`, `max_file_path_length`, `file_extension_restriction`) need GH Pro/Team/Enterprise -- not available on heron's Free + Public tier.

## Motivation

PR #69 ambitiously added 4 push rules to the main ruleset assuming they were available on Free + Public. The branch ruleset PUT failed with HTTP 422 "Invalid rule 'commit_message_pattern'". Moving them to a separate `push.json` (target: push) hit the same 422.

GitHub's Push Rules feature requires:
- GitHub Pro / Team / Enterprise (paid plans), OR
- GitHub Enterprise for advanced rules

heron is currently Free + Public. The rules can't be applied through the REST API on this tier.

The patterns are still enforced at the workflow + lefthook level:
- **Conventional Commits**: lefthook `commit-msg` + `pr-quality` workflow
- **File extension restriction**: `.gitignore` + `no-secrets` pre-commit hook for `.pem` / `.key`
- **File size + path length**: practically never hit; would surface in PR review

If we upgrade to GH Pro later, restore `main.json` + `push.json` from PR #69 and re-run `pnpm gh:apply`.

## What stays

- Tag ruleset (`tags.json`) — applied live as id 16709185 (`Protect release tags`). Target `tag` IS supported on Free + Public. Tag rules: `deletion`, `non_fast_forward`, `update`, `required_signatures` on `refs/tags/v*`.
- All sticky-comment + stricter-description + new-gate changes from PR #69 stay (unaffected).

## Test plan

- [x] `gh:verify` exits 0 (no drift)
- [x] `gh api repos/kaelys-js/heron/rulesets` shows id 16709185 active
- [x] Local lefthook commit-msg + signoff still gating commits

## Migration

For maintainers on Free + Public: nothing changes. Patterns continue to be enforced by lefthook + workflows.

For maintainers who later upgrade to GH Pro: re-add the 4 push rules by reverting this commit (`git revert <sha>`) and recreate `push.json` from PR #69's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed file size, path length, file extension restriction, and commit message pattern enforcement rules from the repository ruleset configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->