### PR TITLE
feat(ci): pr content gates + pre-push parity + shellcheck via mise

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -44,6 +44,10 @@
           { "context": "OSSF Scorecard / Scorecard analysis" },
           { "context": "zizmor — workflow security scan / Scan workflows" },
           { "context": "PR quality / Conventional Commits PR title" },
+          { "context": "PR content gates / Per-commit Conventional Commits" },
+          { "context": "PR content gates / File size <= 5MB" },
+          { "context": "PR content gates / Path length <= 255 chars" },
+          { "context": "PR content gates / File extensions allowlist" },
           { "context": "DCO" }
         ]
       }

--- a/.github/workflows/pr-content-gates.yml
+++ b/.github/workflows/pr-content-gates.yml
@@ -1,0 +1,125 @@
+name: PR content gates
+# Replacement gates for the 4 Enterprise-only ruleset rules we cannot
+# apply on a personal-account Free + public repo:
+#
+#   1. `commit_message_pattern`       (Enterprise only) → per-commit Conventional Commits + DCO
+#   2. `max_file_size`                (Team org-owned private only) → file size <= 5MB
+#   3. `max_file_path_length`         (Team org-owned private only) → path length <= 255 chars
+#   4. `file_extension_restriction`   (Team org-owned private only) → file extensions allowlist
+#
+# Each job becomes a required status check in `.github/rulesets/main.json`,
+# so the gate quality matches what the ruleset rules would have given us.
+#
+# Lefthook pre-push mirrors each gate (same logic, same exit codes) so
+# violations are caught before the PR is pushed.
+#
+# Required-check contexts (referenced by main.json + verify-required-checks):
+#   PR content gates / Per-commit Conventional Commits
+#   PR content gates / File size <= 5MB
+#   PR content gates / Path length <= 255 chars
+#   PR content gates / File extensions allowlist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-content-gates-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  per-commit-conventional:
+    name: Per-commit Conventional Commits
+    # Lints EVERY commit in the PR (not just the squash title). A
+    # 10-commit branch with one sloppy middle commit fails here.
+    # The squash-merge happy path means the title becomes the commit,
+    # but maintainers may merge-commit certain release-please PRs --
+    # individual commits surviving the merge need to pass too.
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR with full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # fetch every commit in the PR -- needed because we lint each.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Lint every commit in the PR
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Shared with lefthook pre-push via scripts/system/check-content-gates.sh.
+        run: bash scripts/system/check-content-gates.sh per-commit-conventional "$BASE_SHA" "$HEAD_SHA"
+
+  file-size-gate:
+    name: File size <= 5MB
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check that no file added/modified in this PR exceeds 5MB
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/system/check-content-gates.sh file-size "$BASE_SHA" "$HEAD_SHA"
+
+  path-length-gate:
+    name: Path length <= 255 chars
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check that no path added in this PR exceeds 255 chars
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/system/check-content-gates.sh path-length "$BASE_SHA" "$HEAD_SHA"
+
+  file-extensions-gate:
+    name: File extensions allowlist
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Block binary + key extensions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/system/check-content-gates.sh file-extensions "$BASE_SHA" "$HEAD_SHA"

--- a/.mise.toml
+++ b/.mise.toml
@@ -33,7 +33,14 @@ python = "3.13.13"
 # ── Formatters / Linters (managed by mise so fresh-clone works) ──────
 # Every formatter the lefthook + CI gates use must be installable from
 # mise alone — no `brew install` step required for a fresh checkout.
-actionlint = "1.7.12"  # GH Workflow validator + shellcheck
+actionlint = "1.7.12" # GH Workflow validator + shellcheck
+# shellcheck — actionlint integrates with shellcheck to lint the bash
+# inside `run:` blocks in workflows. Without shellcheck on PATH,
+# actionlint silently skips SC* rules — local runs miss bugs that CI
+# (which installs shellcheck via mise) catches. Pinning it here closes
+# that gap. SC2002 (Useless cat) cost a PR a CI cycle on 2026-05-21
+# precisely because shellcheck wasn't on the dev machine.
+shellcheck = "0.10.0"  # Shell linter — pairs with actionlint
 ruff = "0.7.4"         # Python formatter + linter
 shfmt = "3.10.0"       # POSIX shell formatter
 swiftlint = "0.57.1"   # Swift lint gate

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,155 @@
+# CI gates and ruleset model
+
+<!-- AUTO-GENERATED:doc-meta -->
+*Part of the [Heron](../README.md) docs.*
+<!-- /AUTO-GENERATED:doc-meta -->
+
+How `kaelys-js/heron` keeps `main` clean. This document is the single
+reference for **every gate** (pre-commit / pre-push / required CI check
+/ ruleset rule) and **how to bypass each one** when you must.
+
+## Layered defence
+
+| Layer | When it runs | What it catches | Bypass |
+|---|---|---|---|
+| **lefthook `pre-commit`** | local `git commit` | format drift, secret patterns, syntax errors, formatter output | `SKIP_LEFTHOOK=1 git commit ...` |
+| **lefthook `commit-msg`** | local `git commit` | Conventional Commits subject + DCO sign-off trailer | `SKIP_LEFTHOOK=1 git commit ...` |
+| **lefthook `pre-push`** | local `git push` | typecheck, vitest, format-check, strict swiftlint/ruff/ktlint, actionlint+shellcheck, content gates (size/path/extensions/per-commit), release-readiness, PR-title budget | `SKIP_LEFTHOOK=1 git push` |
+| **GitHub status checks** | every PR push | full Vitest matrix, iOS XCTest, CodeQL, OSSF Scorecard, Dependency Review, zizmor, secret scan, DCO, content gates (PR-level), PR quality | label `oversize-ok` / `no-issue` for specific opt-outs |
+| **Ruleset `Protect main branch`** | on `git push origin main` | block force-push, deletion, unsigned commits, missing required-checks, low review count | admin `RepositoryRole 5` bypass |
+| **Ruleset `Protect release tags`** | on `git push origin v*` | block tag deletion, force-update, unsigned tags | admin bypass |
+
+## Required status checks on `main`
+
+The ruleset at `.github/rulesets/main.json` enforces the following
+contexts. PRs cannot merge until each goes green.
+
+| Context | Source workflow | What it gates |
+|---|---|---|
+| `Tests / TS -- typecheck + Vitest + coverage` | `test.yml` | svelte-check + tsgo + Vitest matrix (unit/server/component/route/integration) + 70% coverage floor |
+| `Tests / iOS -- XCTest + XCUITest + Snapshot` | `test.yml` | Fastlane test_ci on iPhone 17 Pro Max sim + xcov 60% floor |
+| `Tests / Lint + format (Python / Go / Kotlin / Shell / Ruby / YAML)` | `test.yml` | actionlint+shellcheck, ruff, ktlint, shfmt, rufo, yamllint, taplo, dotenv-linter, plist + XML validators |
+| `CodeQL Analysis / Analyze (javascript-typescript)` | `codeql.yml` | static analysis for JS/TS |
+| `CodeQL Analysis / Analyze (python)` | `codeql.yml` | static analysis for Python |
+| `CodeQL Analysis / Analyze (swift)` | `codeql.yml` | static analysis for Swift |
+| `Dependency Review / dependency-review` | `dependency-review.yml` | block PRs that add deps with HIGH+ CVEs or copyleft licenses |
+| `OSSF Scorecard / Scorecard analysis` | `scorecard.yml` | weekly Scorecard health score |
+| `zizmor -- workflow security scan / Scan workflows` | `zizmor.yml` | workflow-injection + permission scan |
+| `PR quality / Conventional Commits PR title` | `pr-quality.yml` | PR title matches Conventional Commits |
+| **`PR content gates / Per-commit Conventional Commits`** | `pr-content-gates.yml` | every commit (not just title) matches Conventional Commits |
+| **`PR content gates / File size <= 5MB`** | `pr-content-gates.yml` | block any file > 5MB |
+| **`PR content gates / Path length <= 255 chars`** | `pr-content-gates.yml` | block any path > 255 chars (NTFS limit) |
+| **`PR content gates / File extensions allowlist`** | `pr-content-gates.yml` | block `exe/dll/so/dylib/p8/p12/jks/keystore/pfx/der/crt/cer` |
+| `DCO` | github.com/apps/dco | every commit has `Signed-off-by:` trailer |
+
+**Bold rows** are the 4 gates added in audit cycle 4 to replace the
+Enterprise-only ruleset rules (`commit_message_pattern`, `max_file_size`,
+`max_file_path_length`, `file_extension_restriction`) that aren't
+available on personal-account Free + public repos.
+
+## Why the 4 replacement gates exist
+
+GitHub's ruleset API supports these rule types only on Enterprise (for
+the `*_pattern` family) or Team-plus-org-owned-private (for push-target
+rules):
+
+| Rule type | Real availability |
+|---|---|
+| `commit_message_pattern` | Enterprise Cloud only |
+| `commit_author_email_pattern` | Enterprise Cloud only |
+| `committer_email_pattern` | Enterprise Cloud only |
+| `branch_name_pattern` | Enterprise Cloud only |
+| `tag_name_pattern` | Enterprise Cloud only |
+| `max_file_size` | Team plan + org-owned + private/internal |
+| `max_file_path_length` | Team plan + org-owned + private/internal |
+| `file_extension_restriction` | Team plan + org-owned + private/internal |
+| `file_path_restriction` | Team plan + org-owned + private/internal |
+
+Source: empirical 422 responses from the live API on this repo + the
+`docs.github.com` ruleset reference. See also commit history of
+`.github/rulesets/main.json` for the rollback (PR #70).
+
+The replacement CI gates give the same guarantee -- a PR cannot merge
+to `main` without satisfying each -- without depending on any plan tier.
+
+## Pre-push parity
+
+Every CI gate that's fast (< 2s) and deterministic is mirrored as a
+lefthook pre-push hook so contributors see the failure locally before
+a remote round-trip:
+
+| CI gate | Pre-push hook | Notes |
+|---|---|---|
+| TS typecheck | `typecheck` | turbo-cached; warm < 100ms |
+| Vitest | `vitest` | full matrix; warm < 100ms |
+| biome / prettier | `format-check` | auto-recovers on drift |
+| swiftlint --strict | `swiftlint-strict` | iOS only |
+| ktlint | `ktlint-strict` | Android only |
+| ruff | `ruff-strict` | Python |
+| actionlint + shellcheck | `actionlint` | `-shellcheck=shellcheck` explicit |
+| Per-commit Conventional Commits | `per-commit-conventional` | rev-list since `origin/main` |
+| File size <= 5MB | `file-size-gate` | diff since `origin/main` |
+| Path length <= 255 chars | `path-length-gate` | diff since `origin/main` |
+| File extensions allowlist | `file-extensions-gate` | diff since `origin/main` |
+| PR title <= 72 chars | `pr-title-budget` | requires existing PR; skips first push |
+| Release readiness | `release-readiness` | only fires on tag push |
+
+Bypass any of these for the rare emergency: `SKIP_LEFTHOOK=1 git push`.
+Don't make a habit of it -- CI re-runs everything anyway, you're just
+delaying the inevitable.
+
+## Bypass labels (CI-only opt-outs)
+
+Some CI checks accept labels as an opt-out:
+
+| Label | What it bypasses |
+|---|---|
+| `oversize-ok` | `PR quality / Max PR size` (2000 LOC budget) |
+| `no-issue` | `PR quality / feat PRs must link an issue` |
+
+Use labels sparingly -- they're for cases like "Renovate lockfile bump
+crosses 2000 LOC by design" or "this is a hotfix that needs to ship
+before the issue is filed."
+
+## Admin bypass
+
+The bypass actor `RepositoryRole 5` (Admin) with `bypass_mode: always`
+on both rulesets lets you `gh pr merge --admin` to override required
+checks. Use case: emergency rollback when CI itself is broken.
+
+Never use admin-merge to skip a check that's failing on its own
+merits -- fix the underlying issue.
+
+## Local development
+
+```sh
+# One-time setup
+mise install         # installs Node + pnpm + Ruby + Python + every linter
+pnpm install         # also runs `lefthook install` to wire git hooks
+
+# Daily commands
+pnpm dev             # turbo dev server
+pnpm test            # full Vitest matrix
+pnpm check           # svelte-check + tsgo
+pnpm format          # biome write
+pnpm format:check    # biome check (CI mirror)
+
+# Manual hook invocation
+lefthook run pre-commit
+lefthook run pre-push --commands vitest
+lefthook run pre-push --commands per-commit-conventional
+```
+
+## Adding a new required check
+
+1. Add the workflow + job in `.github/workflows/<workflow>.yml`.
+2. Add the context string to `required_status_checks` in
+   `.github/rulesets/main.json`.
+3. Apply the ruleset live: `pnpm gh:apply` (or via PR; the SSOT JSON +
+   `verify-gh-config.yml` will keep them in sync going forward).
+4. Optionally add a pre-push mirror in `lefthook.yml`.
+5. Update this document.
+
+The `verify-required-checks.yml` workflow asserts every context string
+in `main.json` matches an actual workflow job -- so a typo'd context
+fails CI on PR-time.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -109,7 +109,7 @@ pre-commit:
       # `pnpm fonts:lock` after a deliberate font upgrade.
       glob: "ui/static/fonts/*"
       run: node scripts/system/verify-fonts.mjs
-      fail_text: "woff2 drift — see verify-fonts output. Run `pnpm fonts:lock` after a deliberate font swap."
+      fail_text: "woff2 drift -- see verify-fonts output. Run `pnpm fonts:lock` after a deliberate font swap."
 
     # NOTE: biome-format / sort-package-json / biome-format-check were
     # merged into the `format-pipeline` command above so they run in
@@ -477,7 +477,7 @@ pre-push:
       #   - If it doesn't AND mise isn't usable → falls into the
       #     actionable error message from ensure-pnpm.mjs.
       run: bash scripts/system/mise-shim.sh node scripts/system/ensure-pnpm.mjs
-      fail_text: "Node version doesn't match engines pin. mise isn't installed or doesn't have the pinned Node version — see message above."
+      fail_text: "Node version doesn't match engines pin. mise isn't installed or doesn't have the pinned Node version -- see message above."
     typecheck:
       # svelte-check (ui) + tsgo (electron), turbo-cached.
       # Cold ~12s, warm <100ms. Wrapped in mise-shim so it auto-routes
@@ -515,7 +515,7 @@ pre-push:
       run: |
         bash scripts/system/mise-shim.sh sh -c '
           node scripts/native/ensure-native-bindings.mjs --quiet || {
-            echo "✗ native bindings unhealthy — run \`pnpm rebuild:native\` to fix."
+            echo "✗ native bindings unhealthy -- run \`pnpm rebuild:native\` to fix."
             exit 1
           }
           pnpm exec turbo run test:coverage
@@ -554,7 +554,7 @@ pre-push:
         fi
         echo "✗ Format drift detected. Auto-formatting…"
         bash scripts/system/mise-shim.sh pnpm format > /dev/null 2>&1 || {
-          echo "  (pnpm format itself failed — run it manually to see the error)"
+          echo "  (pnpm format itself failed -- run it manually to see the error)"
           exit 1
         }
         CHANGED=$(git diff --name-only)
@@ -604,8 +604,45 @@ pre-push:
     actionlint:
       # Lint .github/workflows/*.yml -- catches typos / unknown action inputs
       # / job-needs cycles before they ever hit GitHub. Free + fast.
+      #
+      # `-shellcheck=shellcheck` makes the shellcheck integration EXPLICIT
+      # so it fails loudly if shellcheck isn't on PATH (rather than silently
+      # skipping SC* rules, which is what bit PR #69 with SC2002 reaching
+      # remote). shellcheck is pinned in .mise.toml -- `mise install` puts
+      # it on PATH.
       glob: ".github/workflows/*.{yml,yaml}"
-      run: actionlint {staged_files} 2>/dev/null || actionlint .github/workflows/*.yml
+      run: actionlint -shellcheck=shellcheck {staged_files} 2>/dev/null || actionlint -shellcheck=shellcheck .github/workflows/*.yml
+
+    pr-title-budget:
+      # When the current branch has an open PR, fetch its title via `gh pr view`
+      # and apply the 72-char budget that pr-quality.yml's "PR title <= 72 chars"
+      # check enforces. Skip when no PR exists yet (first push from a new branch).
+      #
+      # Caught locally instead of after a remote round-trip: PR #69 took an
+      # extra CI cycle because the title was 81 chars; this hook would have
+      # rejected the push and saved that round-trip.
+      #
+      # Bypass: SKIP_LEFTHOOK=1 git push (or simply trim the title via gh pr edit).
+      run: |
+        command -v gh >/dev/null 2>&1 || { echo "skip: gh CLI not installed"; exit 0; }
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        # Skip the check when pushing main, release tags, dependabot branches, or in detached HEAD.
+        case "$BRANCH" in
+          main|HEAD|dependabot/*|release-please--*) exit 0 ;;
+        esac
+        TITLE=$(gh pr view --json title --jq .title 2>/dev/null || true)
+        if [ -z "$TITLE" ]; then
+          # No PR yet -- first push from a feature branch. The check fires on subsequent pushes.
+          exit 0
+        fi
+        LEN=${#TITLE}
+        if [ "$LEN" -gt 72 ]; then
+          echo "✗ PR title is $LEN chars; budget is 72."
+          echo "  Title: $TITLE"
+          echo "  Fix:   gh pr edit --title \"<shorter title>\""
+          echo "  Bypass: SKIP_LEFTHOOK=1 git push"
+          exit 1
+        fi
     release-readiness:
       # When pushing a release tag (v1.2.3 / v1.2.3-beta.1), gate on
       # native-release readiness. This catches "I forgot to run
@@ -627,6 +664,22 @@ pre-push:
         echo "▸ Release tag(s) detected: $TAG_REFS"
         echo "▸ Running doctor:native to verify CI can release..."
         pnpm doctor:native
+
+    # ── Content gates -- mirror .github/workflows/pr-content-gates.yml ──
+    # The 4 Enterprise-only ruleset rules we couldn't apply on Free + public
+    # (commit_message_pattern / max_file_size / max_file_path_length /
+    # file_extension_restriction) are now CI required-checks. Catching the
+    # same violations pre-push saves a CI round-trip. Logic shared with CI
+    # via scripts/system/check-content-gates.sh so there's no drift between
+    # the local + remote gate behaviour.
+    per-commit-conventional:
+      run: bash scripts/system/check-content-gates.sh per-commit-conventional
+    file-size-gate:
+      run: bash scripts/system/check-content-gates.sh file-size
+    path-length-gate:
+      run: bash scripts/system/check-content-gates.sh path-length
+    file-extensions-gate:
+      run: bash scripts/system/check-content-gates.sh file-extensions
 
 # ── commit-msg (lightweight) ────────────────────────────────────────
 # Enforce Conventional Commits format (so release-please can generate

--- a/mise.lock
+++ b/mise.lock
@@ -301,6 +301,32 @@ url = "https://github.com/astral-sh/ruff/releases/download/0.7.4/ruff-x86_64-app
 checksum = "sha256:d6c1c7ecfcce022f87a172ed8586f068f616e9844d6ee5d2527dfcfb7348f45c"
 url = "https://github.com/astral-sh/ruff/releases/download/0.7.4/ruff-x86_64-pc-windows-msvc.zip"
 
+[[tools.shellcheck]]
+version = "0.10.0"
+backend = "aqua:koalaman/shellcheck"
+
+[tools.shellcheck."platforms.linux-arm64"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-arm64-musl"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.linux-x64-musl"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.macos-arm64"]
+checksum = "blake3:a03f7e89a3ae96103d5a425053566ff0643ce8aa1a0bee7fd0f09da50c18b41c"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.aarch64.tar.xz"
+
+[tools.shellcheck."platforms.macos-x64"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.x86_64.tar.xz"
+
+[tools.shellcheck."platforms.windows-x64"]
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.zip"
+
 [[tools.shfmt]]
 version = "3.10.0"
 backend = "aqua:mvdan/sh"

--- a/scripts/native/apply-brand.mjs
+++ b/scripts/native/apply-brand.mjs
@@ -1159,6 +1159,7 @@ function applyMarkdownSections(brand) {
     join(ROOT, '.github', 'SECURITY.md'),
     // docs/
     join(ROOT, 'docs', 'ARCHITECTURE.md'),
+    join(ROOT, 'docs', 'CI.md'),
     join(ROOT, 'docs', 'COMMENT-STYLE.md'),
     join(ROOT, 'docs', 'COMPARISON.md'),
     join(ROOT, 'docs', 'CUSTOMIZATION.md'),

--- a/scripts/system/check-content-gates.sh
+++ b/scripts/system/check-content-gates.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Shared logic for the 4 PR content gates, replacing the Enterprise-only
+# ruleset rules we can't apply on this Free + public + personal-account repo.
+# Invoked by both .github/workflows/pr-content-gates.yml (CI) and
+# lefthook.yml (pre-push) so the same logic produces the same outcome
+# everywhere -- no CI-vs-local drift.
+#
+# Usage:
+#   check-content-gates.sh <gate> [<base-ref> [<head-ref>]]
+#
+# <gate> = per-commit-conventional | file-size | path-length | file-extensions | all
+# <base-ref> defaults to merge-base with origin/main (pre-push mode)
+#            or $BASE_SHA env var (CI mode, set from pull_request.base.sha)
+# <head-ref> defaults to HEAD (pre-push) or $HEAD_SHA env var (CI)
+#
+# Exits 0 on pass, 1 on violations found. Each gate prints a human-readable
+# table on failure (with $GITHUB_STEP_SUMMARY-friendly markdown when on CI).
+
+set -euo pipefail
+
+GATE="${1:-all}"
+BASE="${2:-${BASE_SHA:-}}"
+HEAD="${3:-${HEAD_SHA:-HEAD}}"
+
+# Resolve BASE if not explicitly provided.
+if [ -z "$BASE" ]; then
+  BASE=$(git merge-base origin/main HEAD 2>/dev/null || true)
+fi
+if [ -z "$BASE" ] || [ "$BASE" = "$(git rev-parse "$HEAD" 2>/dev/null)" ]; then
+  # No divergence -- nothing to check (e.g. first push from new branch when origin/main IS HEAD).
+  exit 0
+fi
+
+# Detect environment for output format. CI sets GITHUB_STEP_SUMMARY.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  SUMMARY="$GITHUB_STEP_SUMMARY"
+else
+  SUMMARY=/dev/stderr
+fi
+
+# ---- Gate 1: per-commit Conventional Commits ----------------------------
+gate_per_commit_conventional() {
+  # Pattern mirrors lefthook commit-msg hook + main.json's eventual
+  # commit_message_pattern rule (when Enterprise unlocks it).
+  PATTERN='^((Merge|Revert|fixup!|squash!|chore\(main\): release|chore\(deps\)|Bump)|(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9_-]+\))?!?: .{1,72})'
+  FAILED=""
+  while IFS= read -r sha; do
+    [ -z "$sha" ] && continue
+    subject=$(git log -1 --format=%s "$sha")
+    if ! printf '%s' "$subject" | grep -qE "$PATTERN"; then
+      FAILED+="| \`${sha:0:7}\` | ${subject} |"$'\n'
+    fi
+  done <<EOF
+$(git rev-list --no-merges "${BASE}..${HEAD}")
+EOF
+  if [ -n "$FAILED" ]; then
+    {
+      echo "## ❌ Per-commit Conventional Commits"
+      echo ""
+      echo "The following commits don't match the Conventional Commits grammar:"
+      echo ""
+      echo "| SHA | Subject |"
+      echo "|---|---|"
+      printf '%s' "$FAILED"
+      echo ""
+      echo "**Fix:** \`git rebase -i ${BASE:0:7}\` and reword each non-conforming subject."
+      echo "Each must match: \`<type>(<scope>)!: <subject>\` (72 chars max)."
+      echo "Allowed types: feat fix chore docs style refactor perf test build ci revert"
+    } >>"$SUMMARY"
+    return 1
+  fi
+  return 0
+}
+
+# ---- Gate 2: file size <= 5MB ------------------------------------------
+gate_file_size() {
+  MAX_BYTES=5242880 # 5 * 1024 * 1024
+  FAILED=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    [ -f "$path" ] || continue
+    # stat -c (GNU) and stat -f (BSD/macOS) differ; try both.
+    size=$(stat -c %s "$path" 2>/dev/null || stat -f %z "$path" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$MAX_BYTES" ]; then
+      if [ "$size" -ge 1048576 ]; then
+        hsize=$(awk "BEGIN{printf \"%.2f MB\", $size/1048576}")
+      else
+        hsize=$(awk "BEGIN{printf \"%.1f KB\", $size/1024}")
+      fi
+      FAILED+="| \`$path\` | $hsize |"$'\n'
+    fi
+  done <<EOF
+$(git diff --diff-filter=AM --name-only "${BASE}..${HEAD}")
+EOF
+  if [ -n "$FAILED" ]; then
+    {
+      echo "## ❌ File size > 5MB"
+      echo ""
+      echo "| Path | Size |"
+      echo "|---|--:|"
+      printf '%s' "$FAILED"
+      echo ""
+      echo "**Fix:** use Git LFS for large binaries, or compress/relocate."
+      echo "The 5MB cap exists to keep git history fast for fresh clones."
+    } >>"$SUMMARY"
+    return 1
+  fi
+  return 0
+}
+
+# ---- Gate 3: path length <= 255 chars ----------------------------------
+gate_path_length() {
+  MAX_LEN=255
+  FAILED=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    len=${#path}
+    if [ "$len" -gt "$MAX_LEN" ]; then
+      FAILED+="| $len | \`$path\` |"$'\n'
+    fi
+  done <<EOF
+$(git diff --diff-filter=AM --name-only "${BASE}..${HEAD}")
+EOF
+  if [ -n "$FAILED" ]; then
+    {
+      echo "## ❌ Path length > 255 chars"
+      echo ""
+      echo "| Length | Path |"
+      echo "|---|---|"
+      printf '%s' "$FAILED"
+      echo ""
+      echo "**Why:** Windows NTFS path limit. Cross-platform reproducibility."
+      echo "**Fix:** rename to a shorter path."
+    } >>"$SUMMARY"
+    return 1
+  fi
+  return 0
+}
+
+# ---- Gate 4: file extensions allowlist ---------------------------------
+gate_file_extensions() {
+  # *.pem / *.key are NOT in this list -- they're caught by GitHub
+  # secret-scanning push protection (free on public repos). Doubling up
+  # would create a confusing "two errors for the same thing" experience.
+  BLOCKED='\.(exe|dll|so|dylib|p8|p12|jks|keystore|pfx|der|crt|cer)$'
+  FAILED=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    if printf '%s' "$path" | grep -qiE "$BLOCKED"; then
+      FAILED+="| \`$path\` |"$'\n'
+    fi
+  done <<EOF
+$(git diff --diff-filter=AM --name-only "${BASE}..${HEAD}")
+EOF
+  if [ -n "$FAILED" ]; then
+    {
+      echo "## ❌ Blocked file extension"
+      echo ""
+      echo "| Path |"
+      echo "|---|"
+      printf '%s' "$FAILED"
+      echo ""
+      echo "Blocked: \`exe dll so dylib p8 p12 jks keystore pfx der crt cer\`"
+      echo ""
+      echo "**Why:**"
+      echo "  - Binary executables shouldn't live in repo (use releases / artifacts)"
+      echo "  - Cryptographic key material shouldn't live in repo (use secret manager)"
+      echo ""
+      echo "**Note:** \`*.pem\` / \`*.key\` are blocked by GitHub secret-scanning"
+      echo "push protection, not by this gate."
+    } >>"$SUMMARY"
+    return 1
+  fi
+  return 0
+}
+
+case "$GATE" in
+  per-commit-conventional)
+    gate_per_commit_conventional
+    ;;
+  file-size)
+    gate_file_size
+    ;;
+  path-length)
+    gate_path_length
+    ;;
+  file-extensions)
+    gate_file_extensions
+    ;;
+  all)
+    rc=0
+    gate_per_commit_conventional || rc=1
+    gate_file_size || rc=1
+    gate_path_length || rc=1
+    gate_file_extensions || rc=1
+    exit "$rc"
+    ;;
+  *)
+    echo "Unknown gate: $GATE" >&2
+    echo "Usage: $0 {per-commit-conventional|file-size|path-length|file-extensions|all} [base] [head]" >&2
+    exit 2
+    ;;
+esac

--- a/ui/src/lib/integration/capacitor.integration.test.ts
+++ b/ui/src/lib/integration/capacitor.integration.test.ts
@@ -281,6 +281,7 @@ describe('doc-meta convention — every in-scope .md has AUTO-GENERATED:doc-meta
     '.github/CONTRIBUTING.md',
     '.github/SECURITY.md',
     'docs/ARCHITECTURE.md',
+    'docs/CI.md',
     'docs/COMMENT-STYLE.md',
     'docs/COMPARISON.md',
     'docs/CUSTOMIZATION.md',


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `534c4d2` (run [#206](https://github.com/kaelys-js/heron/actions/runs/26244227240))
<!-- CI-STATUS-MARKER-END -->

## Summary

- Replace 4 Enterprise-only ruleset rules (`commit_message_pattern`, `max_file_size`, `max_file_path_length`, `file_extension_restriction`) with equivalent **CI required checks** so we get the same protection on personal-account Free + public repos.
- Add lefthook pre-push parity for the new gates + `shellcheck` integration via mise so PR #69-style SC2002 leaks don't recur.
- New `docs/CI.md` documents every gate (required + informational) + how to bypass each.

## Motivation

Last cycle (PR #70) we discovered that 4 ruleset rule types are tier-gated on GitHub:
- `commit_message_pattern` and 4 other `*_pattern` rules → **Enterprise Cloud only**
- `max_file_size`, `max_file_path_length`, `file_extension_restriction`, `file_path_restriction` → **Team plan + org-owned + private/internal**

Since `kaelys-js/heron` is **public on a personal account on Free**, none of these are available. PR #70 dropped them with a confusing "Free+Public can't apply them" message. This PR provides the same guarantees via mechanisms that DO work on this repo.

## Changes

### New CI workflow (`pr-content-gates.yml`) — 4 required checks

| Context | Replaces | What it enforces |
|---|---|---|
| `PR content gates / Per-commit Conventional Commits` | `commit_message_pattern` | Lints every commit in the PR (not just the title) against the Conventional Commits grammar + 72-char subject |
| `PR content gates / File size <= 5MB` | `max_file_size` | Block any added/modified file > 5MB |
| `PR content gates / Path length <= 255 chars` | `max_file_path_length` | Block any path > 255 chars (Windows NTFS limit) |
| `PR content gates / File extensions allowlist` | `file_extension_restriction` | Block `exe / dll / so / dylib / p8 / p12 / jks / keystore / pfx / der / crt / cer`. `*.pem` / `*.key` covered by GitHub secret-scanning push protection. |

### Single source of truth (`scripts/system/check-content-gates.sh`)

Gate logic lives in one bash script invoked by **both** CI and lefthook pre-push. No drift between the local and remote gate behaviour.

### Pre-push parity (`lefthook.yml`)

- `shellcheck` pinned in `.mise.toml` (was missing — caused PR #69 to leak SC2002 "Useless cat" past local `actionlint` to CI because `actionlint` silently skips SC* rules without shellcheck on PATH).
- `actionlint` hook now uses `-shellcheck=shellcheck` explicitly so missing shellcheck fails loudly.
- New `pr-title-budget` hook fetches the current PR title via `gh pr view` and applies the 72-char budget locally. Skips when no PR exists yet (first push).
- 4 new pre-push hooks mirror each CI content gate.

### `main.json` ruleset update

Added the 4 new context strings as required status checks.

### `docs/CI.md`

Comprehensive inventory of every gate (required + informational), pre-push parity table, bypass labels (`oversize-ok`, `no-issue`), admin-bypass, and how to add new required checks.

## Test plan

- [x] `scripts/system/check-content-gates.sh all` passes against this branch
- [x] Synthetic test: bad commit subject + `.exe` file both correctly fail with markdown tables
- [x] `lefthook validate` clean
- [x] `actionlint -shellcheck=shellcheck .github/workflows/*.yml` clean
- [x] `yamllint --no-warnings` on all changed files clean
- [x] `pnpm exec vitest run src/lib/integration/capacitor.integration.test.ts` — 86 passed (including new SCOPED_DOCS entry for docs/CI.md)
- [x] Full pre-push gauntlet passes locally before push
- [ ] CI green on this PR (the gates will run against themselves — meta validation)
- [ ] Apply `main.json` ruleset live via `pnpm gh:apply` after merge so the 4 new contexts become required on next PR

## Notes

- **No Copilot anything**, per direction.
- This is PR α of 5 in audit cycle 4. PR β (sticky-comment composite + coverage + quality bots), γ (10 more sticky bots), δ (GitHub features additions), ε (settings doc) will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR content validation gates enforcing per-commit Conventional Commits, 5MB file size limits, 255-character path length limits, and file extension restrictions.

* **Chores**
  * Enhanced CI/CD workflow with automated content gate checks.
  * Updated development toolchain configuration.
  * Added comprehensive CI documentation and improved local development hooks for PR validation parity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->