### PR TITLE
feat(ci): sticky-comment framework + coverage + quality bots

### DIFF
--- a/.github/actions/sticky-comment/action.yml
+++ b/.github/actions/sticky-comment/action.yml
@@ -1,0 +1,109 @@
+name: 'Heron sticky comment'
+description: 'Post or update a single sticky PR comment, identified by marker. Wraps marocchino/sticky-pull-request-comment for the marker primitive + adds Heron-specific footer + body composition.'
+author: 'Heron CI'
+
+inputs:
+  marker:
+    description: 'Marker that identifies the comment, e.g. `heron-pr-coverage`. Each marker is one sticky comment on the PR. Convention: `heron-pr-<type>`.'
+    required: true
+  body-path:
+    description: 'File containing the markdown body. Mutually exclusive with `body`.'
+    required: false
+  body:
+    description: 'Inline markdown body. Mutually exclusive with `body-path`.'
+    required: false
+  pr-number:
+    description: 'PR number. Auto-detected on pull_request events; required on workflow_run events.'
+    required: false
+  mode:
+    description: 'upsert | recreate | delete | hide. Default `upsert` (edit-in-place or create).'
+    required: false
+    default: 'upsert'
+  hide-classify:
+    description: 'When `mode: hide`, the classify reason. Default `OUTDATED`. Other values: `OFF_TOPIC`, `RESOLVED`, `DUPLICATE`, `SPAM`, `ABUSE`.'
+    required: false
+    default: 'OUTDATED'
+  footer:
+    description: 'Append the standard footer (timestamp + short SHA + docs link). Set to "false" to suppress.'
+    required: false
+    default: 'true'
+  github-token:
+    description: 'Token used to post the comment. Defaults to GITHUB_TOKEN. Needs `pull-requests: write`.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  comment-id:
+    description: 'The ID of the created or updated comment'
+    value: ${{ steps.post.outputs.created_comment_id || steps.post.outputs.previous_comment_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compose body
+      id: compose
+      shell: bash
+      env:
+        # Quote every input so multi-line / special-character bodies don't break the shell.
+        STICKY_MARKER: ${{ inputs.marker }}
+        STICKY_BODY_PATH: ${{ inputs.body-path }}
+        STICKY_BODY: ${{ inputs.body }}
+        STICKY_FOOTER: ${{ inputs.footer }}
+        # Forward repo + commit context to the footer.
+        STICKY_REPO: ${{ github.repository }}
+        STICKY_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        # Validation: exactly one of body / body-path must be provided.
+        if [ -z "$STICKY_BODY" ] && [ -z "$STICKY_BODY_PATH" ]; then
+          echo "::error::sticky-comment requires either `body` or `body-path`." >&2
+          exit 1
+        fi
+        if [ -n "$STICKY_BODY" ] && [ -n "$STICKY_BODY_PATH" ]; then
+          echo "::error::sticky-comment: provide either `body` OR `body-path`, not both." >&2
+          exit 1
+        fi
+
+        OUT="${RUNNER_TEMP:-/tmp}/sticky-${STICKY_MARKER}.md"
+
+        # Marker comment on first line. Even though marocchino uses `header:`
+        # for its own dedup, an HTML-comment marker in the body itself makes
+        # the sticky discoverable in `gh api .../comments` output without
+        # knowing marocchino's internal scheme.
+        printf '<!-- %s -->\n' "$STICKY_MARKER" >"$OUT"
+
+        # Append the body content.
+        if [ -n "$STICKY_BODY_PATH" ]; then
+          cat "$STICKY_BODY_PATH" >>"$OUT"
+        else
+          printf '%s' "$STICKY_BODY" >>"$OUT"
+        fi
+
+        # Standard footer (timestamp + SHA + docs link). Suppressed when
+        # `footer: false`.
+        if [ "$STICKY_FOOTER" = "true" ]; then
+          SHORT_SHA="${STICKY_SHA:0:7}"
+          {
+            echo ""
+            echo "---"
+            printf '_Updated %s UTC -- commit [`%s`](https://github.com/%s/commit/%s) -- [CI docs](https://github.com/%s/blob/main/docs/CI.md)_\n' \
+              "$(date -u +'%Y-%m-%d %H:%M')" "$SHORT_SHA" "$STICKY_REPO" "$STICKY_SHA" "$STICKY_REPO"
+          } >>"$OUT"
+        fi
+
+        echo "body_file=$OUT" >>"$GITHUB_OUTPUT"
+
+    - name: Post or update sticky comment
+      id: post
+      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      with:
+        header: ${{ inputs.marker }}
+        path: ${{ steps.compose.outputs.body_file }}
+        number: ${{ inputs.pr-number }}
+        recreate: ${{ inputs.mode == 'recreate' }}
+        delete: ${{ inputs.mode == 'delete' }}
+        hide: ${{ inputs.mode == 'hide' }}
+        hide_classify: ${{ inputs.hide-classify }}
+        skip_unchanged: true
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/scripts/sticky/discover-coverage.mjs
+++ b/.github/scripts/sticky/discover-coverage.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+/**
+ * discover-coverage.mjs -- auto-discover coverage reports in any format
+ * + emit normalised JSON for the sticky-comment formatter.
+ *
+ * Auto-discovery means: drop a coverage file (lcov / cobertura / istanbul /
+ * clover / xcov) anywhere in the working tree and the next CI run picks
+ * it up. No `.github/coverage-sources.yml` to maintain, no per-workspace
+ * registration. Add a new test suite, get coverage in the sticky for free.
+ *
+ * Recognised formats (probed by filename + content shape):
+ *   - Istanbul / v8 coverage-summary.json  (Vitest, Jest, c8)
+ *   - lcov.info                            (Vitest --coverage with lcov reporter,
+ *                                          Jest, gcov, many others)
+ *   - cobertura.xml                        (xcov for iOS via Fastlane slather;
+ *                                          Python coverage.py; Go gocover-cobertura;
+ *                                          Java JaCoCo)
+ *   - clover.xml                           (PHPUnit, legacy Jest)
+ *   - xcov coverage_report.json            (Fastlane xcov action default)
+ *
+ * Flag/suite name derives from the FIRST meaningful path segment the
+ * coverage file lives under, with `coverage` / `fastlane` / `xcov` etc.
+ * stripped. Examples:
+ *   ui/coverage/lcov.info                       → flag `ui`
+ *   ui/electron/coverage/lcov.info              → flag `ui-electron`
+ *   ui/ios/App/fastlane/coverage/cobertura.xml  → flag `ios`
+ *   coverage/lcov.info                          → flag `default`
+ *
+ * Usage:
+ *   node .github/scripts/sticky/discover-coverage.mjs [--root <path>] [--out <path>]
+ *
+ * Default --root is process.cwd(). Default --out is stdout (the workflow
+ * captures it via `> coverage.json`).
+ *
+ * Output schema:
+ *   {
+ *     "schema_version": 1,
+ *     "scanned_at": "2026-05-21T17:55:00Z",
+ *     "flags": [
+ *       {
+ *         "name": "ui",
+ *         "source_file": "ui/coverage/lcov.info",
+ *         "format": "lcov",
+ *         "lines_pct": 84.32,
+ *         "branches_pct": 71.18,
+ *         "statements_pct": 84.30,
+ *         "functions_pct": 88.10,
+ *         "files_count": 142,
+ *         "missing_lines_count": 1843,
+ *         "top_uncovered_files": [
+ *           { "path": "src/foo.ts", "lines_pct": 12.5, "missing": 234 },
+ *           ...
+ *         ]
+ *       },
+ *       ...
+ *     ]
+ *   }
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    root: { type: 'string', default: process.cwd() },
+    out: { type: 'string' },
+  },
+  allowPositionals: false,
+});
+
+const ROOT = path.resolve(args.root);
+
+// Directories we never walk into -- speeds discovery + avoids spurious matches.
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.svelte-kit',
+  '.turbo',
+  'build',
+  'dist',
+  '_build',
+  'Pods',
+  'SourcePackages',
+  'DerivedData',
+  '.venv',
+  '.gradle',
+  '.next',
+  '.nuxt',
+  '.expo',
+  '.angular',
+  '.cache',
+  'tmp',
+]);
+
+// Filenames that mean coverage, anywhere in the tree.
+const COVERAGE_FILES = new Set([
+  'coverage-summary.json',
+  'lcov.info',
+  'cobertura.xml',
+  'clover.xml',
+  'coverage_report.json',
+]);
+
+function walk(dir, acc = []) {
+  if (!fs.existsSync(dir)) return acc;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(ent.name)) continue;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(full, acc);
+    else if (COVERAGE_FILES.has(ent.name)) acc.push(full);
+  }
+  return acc;
+}
+
+/** Derive flag name from the absolute path of the coverage file.
+ *
+ * Rule: take the LAST meaningful path segment. Drops noise segments
+ * (`coverage`, `fastlane`, `xcov`, `App`, etc.) AND parent workspace
+ * names when there's a more-specific child. Result: Codecov-style
+ * single-word flags (`ui`, `electron`, `ios`) so the sticky table reads
+ * the way reviewers expect.
+ *
+ * Examples:
+ *   ui/coverage/lcov.info                       -> "ui"
+ *   ui/electron/coverage/lcov.info              -> "electron"
+ *   ui/ios/App/fastlane/coverage/cobertura.xml  -> "ios"
+ *   coverage/lcov.info                          -> "default"
+ */
+function flagFromPath(absPath) {
+  const rel = path.relative(ROOT, absPath);
+  const segs = rel.split(path.sep).slice(0, -1); // drop filename
+  const NOISE = new Set([
+    'coverage',
+    'fastlane',
+    'xcov',
+    'reports',
+    'test_output',
+    'test',
+    'output',
+    'src',
+    'lib',
+    'App',
+  ]);
+  const meaningful = segs.filter((s) => !NOISE.has(s));
+  if (meaningful.length === 0) return 'default';
+  // Last meaningful segment wins -- gives Codecov-style flags rather
+  // than path-joined chains like `ui-ios` (which read as "ui and ios"
+  // rather than "the iOS app in the ui workspace").
+  return meaningful[meaningful.length - 1];
+}
+
+/** Detect format by filename + a content sniff for edge cases. */
+function detectFormat(absPath) {
+  const base = path.basename(absPath);
+  if (base === 'coverage-summary.json') return 'istanbul';
+  if (base === 'coverage_report.json') return 'xcov';
+  if (base === 'lcov.info') return 'lcov';
+  if (base === 'cobertura.xml') return 'cobertura';
+  if (base === 'clover.xml') return 'clover';
+  return 'unknown';
+}
+
+// ---- Parsers ----------------------------------------------------------
+
+function parseIstanbul(absPath) {
+  const json = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  const total = json.total || {};
+  const fileEntries = Object.entries(json).filter(([k]) => k !== 'total');
+  const topUncovered = fileEntries
+    .map(([file, m]) => ({
+      // Istanbul stores paths as either absolute or already-relative. Only
+      // relativize when absolute; never push the file through `path.relative`
+      // against an unrelated cwd because that produces nonsense `../../../`
+      // chains when a relative path is treated as cwd-relative.
+      path: path.isAbsolute(file) ? path.relative(ROOT, file) : file,
+      lines_pct: m.lines?.pct ?? 0,
+      missing: (m.lines?.total ?? 0) - (m.lines?.covered ?? 0),
+    }))
+    .filter((r) => r.missing > 0)
+    .sort((a, b) => b.missing - a.missing)
+    .slice(0, 10);
+  return {
+    lines_pct: total.lines?.pct ?? null,
+    branches_pct: total.branches?.pct ?? null,
+    statements_pct: total.statements?.pct ?? null,
+    functions_pct: total.functions?.pct ?? null,
+    files_count: fileEntries.length,
+    missing_lines_count: fileEntries.reduce(
+      (sum, [, m]) => sum + ((m.lines?.total ?? 0) - (m.lines?.covered ?? 0)),
+      0,
+    ),
+    top_uncovered_files: topUncovered,
+  };
+}
+
+function parseLcov(absPath) {
+  const src = fs.readFileSync(absPath, 'utf8');
+  let totalLines = 0;
+  let coveredLines = 0;
+  let totalBranches = 0;
+  let coveredBranches = 0;
+  let totalFunctions = 0;
+  let coveredFunctions = 0;
+  const fileStats = []; // { path, missing, lines_pct }
+
+  let current = null;
+  for (const line of src.split('\n')) {
+    if (line.startsWith('SF:')) {
+      current = { path: line.slice(3).trim(), lf: 0, lh: 0 };
+    } else if (current && line.startsWith('LF:')) {
+      current.lf = parseInt(line.slice(3), 10) || 0;
+    } else if (current && line.startsWith('LH:')) {
+      current.lh = parseInt(line.slice(3), 10) || 0;
+    } else if (line.startsWith('BRF:')) {
+      totalBranches += parseInt(line.slice(4), 10) || 0;
+    } else if (line.startsWith('BRH:')) {
+      coveredBranches += parseInt(line.slice(4), 10) || 0;
+    } else if (line.startsWith('FNF:')) {
+      totalFunctions += parseInt(line.slice(4), 10) || 0;
+    } else if (line.startsWith('FNH:')) {
+      coveredFunctions += parseInt(line.slice(4), 10) || 0;
+    } else if (line.startsWith('end_of_record') && current) {
+      totalLines += current.lf;
+      coveredLines += current.lh;
+      const missing = current.lf - current.lh;
+      const lines_pct = current.lf === 0 ? 100 : (current.lh / current.lf) * 100;
+      fileStats.push({
+        // Same isAbsolute guard as parseIstanbul -- only relativize when
+        // lcov stored an absolute path.
+        path: path.isAbsolute(current.path) ? path.relative(ROOT, current.path) : current.path,
+        lines_pct,
+        missing,
+      });
+      current = null;
+    }
+  }
+
+  const topUncovered = fileStats
+    .filter((r) => r.missing > 0)
+    .sort((a, b) => b.missing - a.missing)
+    .slice(0, 10);
+
+  return {
+    lines_pct: totalLines === 0 ? null : (coveredLines / totalLines) * 100,
+    branches_pct: totalBranches === 0 ? null : (coveredBranches / totalBranches) * 100,
+    statements_pct: null, // lcov doesn't distinguish lines from statements
+    functions_pct: totalFunctions === 0 ? null : (coveredFunctions / totalFunctions) * 100,
+    files_count: fileStats.length,
+    missing_lines_count: totalLines - coveredLines,
+    top_uncovered_files: topUncovered,
+  };
+}
+
+function parseCobertura(absPath) {
+  const src = fs.readFileSync(absPath, 'utf8');
+  // Root attributes give us the rolled-up totals. Regex (not full XML parse)
+  // because cobertura's root tag has the rates as attributes -- low-cost
+  // extraction.
+  const rootMatch = src.match(/<coverage\s+([^>]*?)>/);
+  if (!rootMatch) return zeroShape();
+  const attrs = rootMatch[1];
+  const lineRate = parseFloat((attrs.match(/line-rate=["']([\d.]+)["']/) || [, '0'])[1]);
+  const branchRate = parseFloat((attrs.match(/branch-rate=["']([\d.]+)["']/) || [, '0'])[1]);
+  const linesValid = parseInt((attrs.match(/lines-valid=["'](\d+)["']/) || [, '0'])[1], 10);
+  const linesCovered = parseInt((attrs.match(/lines-covered=["'](\d+)["']/) || [, '0'])[1], 10);
+  // Per-file stats from <class filename="..." line-rate="..." ...>
+  const classRe = /<class\s+([^>]*?)>/g;
+  const fileStats = [];
+  let m;
+  while ((m = classRe.exec(src))) {
+    const a = m[1];
+    const fileMatch = a.match(/filename=["']([^"']+)["']/);
+    const rateMatch = a.match(/line-rate=["']([\d.]+)["']/);
+    if (!fileMatch) continue;
+    const file = fileMatch[1];
+    const rate = rateMatch ? parseFloat(rateMatch[1]) : 0;
+    fileStats.push({ path: file, lines_pct: rate * 100, missing: 0 }); // missing requires inner <lines> parse; skip for cobertura
+  }
+  const topUncovered = fileStats
+    .filter((r) => r.lines_pct < 100)
+    .sort((a, b) => a.lines_pct - b.lines_pct)
+    .slice(0, 10);
+  return {
+    lines_pct: lineRate * 100,
+    branches_pct: branchRate * 100,
+    statements_pct: null,
+    functions_pct: null,
+    files_count: fileStats.length,
+    missing_lines_count: linesValid - linesCovered,
+    top_uncovered_files: topUncovered,
+  };
+}
+
+function parseClover(absPath) {
+  const src = fs.readFileSync(absPath, 'utf8');
+  // Clover root <metrics .../> attributes: statements, coveredstatements, conditionals, coveredconditionals.
+  const metricsMatch = src.match(/<metrics\s+([^/]*?)\/>/);
+  if (!metricsMatch) return zeroShape();
+  const a = metricsMatch[1];
+  const statements = parseInt((a.match(/statements=["'](\d+)["']/) || [, '0'])[1], 10);
+  const coveredStatements = parseInt(
+    (a.match(/coveredstatements=["'](\d+)["']/) || [, '0'])[1],
+    10,
+  );
+  const conditionals = parseInt((a.match(/conditionals=["'](\d+)["']/) || [, '0'])[1], 10);
+  const coveredConditionals = parseInt(
+    (a.match(/coveredconditionals=["'](\d+)["']/) || [, '0'])[1],
+    10,
+  );
+  return {
+    lines_pct: null,
+    branches_pct: conditionals === 0 ? null : (coveredConditionals / conditionals) * 100,
+    statements_pct: statements === 0 ? null : (coveredStatements / statements) * 100,
+    functions_pct: null,
+    files_count: 0,
+    missing_lines_count: statements - coveredStatements,
+    top_uncovered_files: [],
+  };
+}
+
+function parseXcov(absPath) {
+  // Fastlane xcov produces a coverage_report.json with shape:
+  //   { "targets": [ { "name": "...", "coverage": 0.83, "files": [ { "name": "...", "coverage": ... } ] } ] }
+  const json = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  const targets = json.targets || [];
+  let totalLines = 0;
+  let coveredLines = 0;
+  const fileStats = [];
+  for (const t of targets) {
+    for (const f of t.files || []) {
+      const lf = f.executable_lines ?? 0;
+      const lh = f.covered_lines ?? Math.round((f.coverage ?? 0) * lf);
+      totalLines += lf;
+      coveredLines += lh;
+      fileStats.push({
+        path: f.name || f.path || '?',
+        lines_pct: (f.coverage ?? 0) * 100,
+        missing: lf - lh,
+      });
+    }
+  }
+  const topUncovered = fileStats
+    .filter((r) => r.missing > 0)
+    .sort((a, b) => b.missing - a.missing)
+    .slice(0, 10);
+  return {
+    lines_pct: totalLines === 0 ? null : (coveredLines / totalLines) * 100,
+    branches_pct: null,
+    statements_pct: null,
+    functions_pct: null,
+    files_count: fileStats.length,
+    missing_lines_count: totalLines - coveredLines,
+    top_uncovered_files: topUncovered,
+  };
+}
+
+function zeroShape() {
+  return {
+    lines_pct: null,
+    branches_pct: null,
+    statements_pct: null,
+    functions_pct: null,
+    files_count: 0,
+    missing_lines_count: 0,
+    top_uncovered_files: [],
+  };
+}
+
+const PARSERS = {
+  istanbul: parseIstanbul,
+  lcov: parseLcov,
+  cobertura: parseCobertura,
+  clover: parseClover,
+  xcov: parseXcov,
+};
+
+// ---- Main -------------------------------------------------------------
+
+function main() {
+  const found = walk(ROOT);
+  const flagsByName = new Map();
+  for (const file of found) {
+    const format = detectFormat(file);
+    if (format === 'unknown') continue;
+    const flagName = flagFromPath(file);
+    let metrics;
+    try {
+      metrics = PARSERS[format](file);
+    } catch (err) {
+      console.error(`::warning::discover-coverage failed to parse ${file}: ${err.message}`);
+      continue;
+    }
+    // Prefer the format we encountered first per flag -- multiple formats
+    // for the same suite (lcov + cobertura) would otherwise emit two
+    // identical rows. Istanbul tends to be richer than lcov; lcov richer
+    // than cobertura -- but we don't try to merge, just first wins.
+    if (flagsByName.has(flagName)) continue;
+    flagsByName.set(flagName, {
+      name: flagName,
+      source_file: path.relative(ROOT, file),
+      format,
+      ...metrics,
+    });
+  }
+
+  const flags = Array.from(flagsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
+  const payload = {
+    schema_version: 1,
+    scanned_at: new Date().toISOString(),
+    flags,
+  };
+  const out = JSON.stringify(payload, null, 2);
+  if (args.out) {
+    fs.writeFileSync(args.out, out);
+    console.error(`Wrote ${flags.length} flag(s) to ${args.out}`);
+  } else {
+    process.stdout.write(out);
+    process.stdout.write('\n');
+  }
+}
+
+main();

--- a/.github/scripts/sticky/discover-coverage.test.mjs
+++ b/.github/scripts/sticky/discover-coverage.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for discover-coverage.mjs.
+ *
+ * Runs via:  node --test .github/scripts/sticky/discover-coverage.test.mjs
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = path.resolve('.github/scripts/sticky/discover-coverage.mjs');
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-cov-'));
+  return dir;
+}
+
+function rm(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {}
+}
+
+function runDiscover(root) {
+  const out = execFileSync(process.execPath, [SCRIPT, '--root', root], {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+describe('discover-coverage', () => {
+  let repo;
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+  afterEach(() => {
+    rm(repo);
+  });
+
+  it('returns an empty flags list when no coverage files exist', () => {
+    const out = runDiscover(repo);
+    assert.equal(out.schema_version, 1);
+    assert.deepEqual(out.flags, []);
+  });
+
+  it('discovers an Istanbul coverage-summary.json under ui/coverage', () => {
+    const dir = path.join(repo, 'ui', 'coverage');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'coverage-summary.json'),
+      JSON.stringify({
+        total: {
+          lines: { total: 100, covered: 80, pct: 80 },
+          branches: { total: 50, covered: 35, pct: 70 },
+          statements: { total: 100, covered: 80, pct: 80 },
+          functions: { total: 30, covered: 28, pct: 93.33 },
+        },
+        'src/foo.ts': { lines: { total: 50, covered: 30, pct: 60 } },
+        'src/bar.ts': { lines: { total: 50, covered: 50, pct: 100 } },
+      }),
+    );
+    const out = runDiscover(repo);
+    assert.equal(out.flags.length, 1);
+    const flag = out.flags[0];
+    assert.equal(flag.name, 'ui');
+    assert.equal(flag.format, 'istanbul');
+    assert.equal(flag.lines_pct, 80);
+    assert.equal(flag.branches_pct, 70);
+    assert.equal(flag.files_count, 2);
+    assert.equal(flag.missing_lines_count, 20);
+    assert.equal(flag.top_uncovered_files[0].path, 'src/foo.ts');
+  });
+
+  it('discovers an lcov.info under ui/electron/coverage', () => {
+    const dir = path.join(repo, 'ui', 'electron', 'coverage');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'lcov.info'),
+      [
+        'SF:src/main.ts',
+        'LF:50',
+        'LH:40',
+        'BRF:20',
+        'BRH:15',
+        'end_of_record',
+        'SF:src/window.ts',
+        'LF:30',
+        'LH:30',
+        'BRF:10',
+        'BRH:10',
+        'end_of_record',
+      ].join('\n'),
+    );
+    const out = runDiscover(repo);
+    assert.equal(out.flags.length, 1);
+    const flag = out.flags[0];
+    assert.equal(flag.name, 'electron');
+    assert.equal(flag.format, 'lcov');
+    assert.equal(flag.files_count, 2);
+    assert.equal(flag.missing_lines_count, 10);
+    assert.ok(Math.abs(flag.lines_pct - 87.5) < 0.01); // (40+30)/(50+30) = 87.5%
+  });
+
+  it('discovers a cobertura.xml from a fastlane xcov path', () => {
+    const dir = path.join(repo, 'ui', 'ios', 'App', 'fastlane', 'coverage');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'cobertura.xml'),
+      `<?xml version="1.0"?>
+<coverage line-rate="0.83" branch-rate="0.72" lines-valid="1000" lines-covered="830">
+  <packages>
+    <package>
+      <classes>
+        <class name="Foo" filename="src/Foo.swift" line-rate="0.50"/>
+        <class name="Bar" filename="src/Bar.swift" line-rate="1.0"/>
+      </classes>
+    </package>
+  </packages>
+</coverage>`,
+    );
+    const out = runDiscover(repo);
+    assert.equal(out.flags.length, 1);
+    const flag = out.flags[0];
+    assert.equal(flag.name, 'ios');
+    assert.equal(flag.format, 'cobertura');
+    assert.equal(Math.round(flag.lines_pct), 83);
+    assert.equal(Math.round(flag.branches_pct), 72);
+    assert.equal(flag.missing_lines_count, 170);
+  });
+
+  it('discovers multiple flags when multiple coverage roots present', () => {
+    fs.mkdirSync(path.join(repo, 'ui', 'coverage'), { recursive: true });
+    fs.mkdirSync(path.join(repo, 'ui', 'electron', 'coverage'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, 'ui', 'coverage', 'lcov.info'),
+      'SF:src/a.ts\nLF:10\nLH:10\nend_of_record\n',
+    );
+    fs.writeFileSync(
+      path.join(repo, 'ui', 'electron', 'coverage', 'lcov.info'),
+      'SF:src/main.ts\nLF:20\nLH:15\nend_of_record\n',
+    );
+    const out = runDiscover(repo);
+    assert.equal(out.flags.length, 2);
+    const names = out.flags.map((f) => f.name).sort();
+    assert.deepEqual(names, ['electron', 'ui']);
+  });
+
+  it('skips node_modules and build directories', () => {
+    const dir = path.join(repo, 'node_modules', 'foo', 'coverage');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'lcov.info'), 'SF:x\nLF:1\nLH:1\nend_of_record\n');
+    const out = runDiscover(repo);
+    assert.deepEqual(out.flags, []);
+  });
+
+  it('handles a coverage file at the repo root as flag `default`', () => {
+    const dir = path.join(repo, 'coverage');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'coverage-summary.json'),
+      JSON.stringify({ total: { lines: { total: 1, covered: 1, pct: 100 } } }),
+    );
+    const out = runDiscover(repo);
+    assert.equal(out.flags.length, 1);
+    assert.equal(out.flags[0].name, 'default');
+  });
+});

--- a/.github/scripts/sticky/format-coverage.mjs
+++ b/.github/scripts/sticky/format-coverage.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * format-coverage.mjs -- consumes the JSON from discover-coverage.mjs
+ * + an optional baseline (latest `coverage-baseline` artifact on `main`)
+ * and emits the markdown body for the `heron-pr-coverage` sticky.
+ *
+ * Layout (Codecov-inspired, condensed to fit a PR comment):
+ *
+ *   ## ✅ Coverage: 84.32% (▴ +0.18% vs base)
+ *
+ *   | Flag | Lines | Branches | Statements | Functions | Δ Lines |
+ *   |---|---|---|---|---|---|
+ *   | ui  | 84.32% ████████░░ | 71.18% ███████░░░ | 84.30% | 88.10% | ▴ +0.18% |
+ *   | ios | 61.40% ██████░░░░ | --        | --     | --       | = 0.00% |
+ *
+ *   <details><summary>Top uncovered files</summary>
+ *   | Path | Coverage | Missing |
+ *   |---|--:|--:|
+ *   | src/foo.ts | 12.5% | 234 lines |
+ *   ...
+ *   </details>
+ *
+ *   <footer auto-appended by the composite action>
+ *
+ * Usage:
+ *   node .github/scripts/sticky/format-coverage.mjs <current.json> [baseline.json] [--out <path>]
+ *
+ * Exit 0 always; the comment itself signals the verdict via emoji header.
+ */
+
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import {
+  EMOJI,
+  statusEmoji,
+  deltaCell,
+  pctBar,
+  collapsibleSection,
+  table,
+  verdictHeader,
+} from './lib.mjs';
+
+const { values: opts, positionals } = parseArgs({
+  options: {
+    out: { type: 'string' },
+    // The lines-pct floor that decides ✅ vs ❌ verdict at the top.
+    // Configurable so this script can format coverage for any project
+    // not just Heron. Default mirrors `ui/vitest.config.ts` (70%).
+    threshold: { type: 'string', default: '70' },
+  },
+  allowPositionals: true,
+});
+
+const currentPath = positionals[0];
+const baselinePath = positionals[1] || null;
+if (!currentPath) {
+  console.error('Usage: format-coverage.mjs <current.json> [baseline.json] [--out <path>]');
+  process.exit(2);
+}
+
+const current = JSON.parse(fs.readFileSync(currentPath, 'utf8'));
+const baseline =
+  baselinePath && fs.existsSync(baselinePath)
+    ? JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+    : { flags: [] };
+
+const threshold = parseFloat(opts.threshold);
+
+// Find baseline flag matching a current flag by name.
+function baselineFor(name) {
+  return (baseline.flags || []).find((f) => f.name === name);
+}
+
+// Compute the OVERALL lines_pct across all flags as a weighted average
+// (by file count). Falls back to simple average if file_counts unknown.
+function overall(flags) {
+  const usable = flags.filter((f) => typeof f.lines_pct === 'number');
+  if (usable.length === 0) return null;
+  const weighted = usable.reduce((s, f) => s + f.lines_pct * (f.files_count || 1), 0);
+  const denom = usable.reduce((s, f) => s + (f.files_count || 1), 0);
+  return denom === 0 ? null : weighted / denom;
+}
+
+const overallCurrent = overall(current.flags);
+const overallBaseline = overall(baseline.flags || []);
+const overallDelta =
+  overallCurrent != null && overallBaseline != null ? overallCurrent - overallBaseline : null;
+
+const verdict = overallCurrent != null && overallCurrent >= threshold ? 'pass' : 'fail';
+const overallStr = overallCurrent != null ? `${overallCurrent.toFixed(2)}%` : '--';
+const deltaStr =
+  overallDelta != null ? deltaCell(overallBaseline, overallCurrent, { threshold: 0.05 }) : '';
+
+// Build per-flag table.
+const rows = current.flags.map((f) => {
+  const b = baselineFor(f.name);
+  const pct =
+    typeof f.lines_pct === 'number'
+      ? `${f.lines_pct.toFixed(2)}% ${pctBar(f.lines_pct, 10)}`
+      : '--';
+  const br = typeof f.branches_pct === 'number' ? `${f.branches_pct.toFixed(2)}%` : '--';
+  const st = typeof f.statements_pct === 'number' ? `${f.statements_pct.toFixed(2)}%` : '--';
+  const fn = typeof f.functions_pct === 'number' ? `${f.functions_pct.toFixed(2)}%` : '--';
+  const delta =
+    b && typeof b.lines_pct === 'number' && typeof f.lines_pct === 'number'
+      ? deltaCell(b.lines_pct, f.lines_pct, { threshold: 0.05 })
+      : '🆕';
+  return {
+    Flag: `\`${f.name}\``,
+    Lines: pct,
+    Branches: br,
+    Statements: st,
+    Functions: fn,
+    'Δ Lines': delta,
+  };
+});
+
+// Build top-uncovered-files collapsible (aggregated across flags).
+const allUncovered = current.flags.flatMap((f) =>
+  (f.top_uncovered_files || []).map((u) => ({ flag: f.name, ...u })),
+);
+allUncovered.sort((a, b) => b.missing - a.missing);
+const topRows = allUncovered.slice(0, 15).map((u) => ({
+  Flag: `\`${u.flag}\``,
+  Path: `\`${u.path}\``,
+  Coverage: `${u.lines_pct.toFixed(2)}%`,
+  Missing: u.missing > 0 ? `${u.missing} lines` : '--',
+}));
+
+const lines = [];
+lines.push(
+  verdictHeader(`Coverage: ${overallStr}${deltaStr ? ` (${deltaStr} vs base)` : ''}`, verdict),
+);
+if (overallCurrent != null && overallCurrent < threshold) {
+  lines.push('');
+  lines.push(
+    `> :warning: Overall coverage is below the **${threshold}%** floor configured in \`ui/vitest.config.ts\`.`,
+  );
+}
+lines.push('');
+
+if (rows.length === 0) {
+  lines.push(
+    '_No coverage reports found. Did the test suite emit any of `coverage-summary.json` / `lcov.info` / `cobertura.xml` / `coverage_report.json`?_',
+  );
+} else {
+  lines.push(
+    table(
+      [
+        { label: 'Flag' },
+        { label: 'Lines' },
+        { label: 'Branches', align: 'right' },
+        { label: 'Statements', align: 'right' },
+        { label: 'Functions', align: 'right' },
+        { label: 'Δ Lines', align: 'right' },
+      ],
+      rows,
+    ),
+  );
+}
+
+if (topRows.length > 0) {
+  lines.push('');
+  lines.push(
+    collapsibleSection(
+      `Top ${topRows.length} files with most missing lines (across all flags)`,
+      table(
+        [
+          { label: 'Flag' },
+          { label: 'Path' },
+          { label: 'Coverage', align: 'right' },
+          { label: 'Missing', align: 'right' },
+        ],
+        topRows,
+      ),
+    ),
+  );
+}
+
+lines.push('');
+lines.push(
+  '<sub>auto-discovered from any `coverage-summary.json` / `lcov.info` / `cobertura.xml` / `clover.xml` / `coverage_report.json` under the working tree. Add a new test suite -> coverage shows up here automatically.</sub>',
+);
+
+const out = lines.join('\n') + '\n';
+if (opts.out) {
+  fs.writeFileSync(opts.out, out);
+  console.error(`Wrote ${out.length} bytes to ${opts.out}`);
+} else {
+  process.stdout.write(out);
+}

--- a/.github/scripts/sticky/format-coverage.test.mjs
+++ b/.github/scripts/sticky/format-coverage.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for format-coverage.mjs.
+ * Run: node --test .github/scripts/sticky/format-coverage.test.mjs
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = path.resolve('.github/scripts/sticky/format-coverage.mjs');
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'format-cov-'));
+}
+
+function runFormat(currentJson, baselineJson) {
+  const dir = makeTmp();
+  const curPath = path.join(dir, 'current.json');
+  fs.writeFileSync(curPath, JSON.stringify(currentJson));
+  const args = [SCRIPT, curPath];
+  if (baselineJson) {
+    const basePath = path.join(dir, 'baseline.json');
+    fs.writeFileSync(basePath, JSON.stringify(baselineJson));
+    args.push(basePath);
+  }
+  const out = execFileSync(process.execPath, args, { encoding: 'utf8' });
+  fs.rmSync(dir, { recursive: true, force: true });
+  return out;
+}
+
+describe('format-coverage', () => {
+  it('renders an empty body when no flags exist', () => {
+    const out = runFormat({ flags: [] });
+    assert.ok(out.includes('No coverage reports found'));
+  });
+
+  it('renders a single-flag table with a percentage bar', () => {
+    const out = runFormat({
+      flags: [
+        {
+          name: 'ui',
+          format: 'istanbul',
+          lines_pct: 84.32,
+          branches_pct: 71.18,
+          statements_pct: 84.3,
+          functions_pct: 88.1,
+          files_count: 142,
+          missing_lines_count: 1843,
+          top_uncovered_files: [],
+        },
+      ],
+    });
+    assert.ok(out.includes('## ✅ Coverage:'), 'top-line verdict missing');
+    assert.ok(out.includes('| `ui` |'), 'ui flag row missing');
+    assert.ok(out.includes('84.32%'), 'lines_pct missing');
+    assert.ok(out.includes('█'), 'pctBar character missing');
+  });
+
+  it('renders multiple flags + delta vs base', () => {
+    const current = {
+      flags: [
+        {
+          name: 'ui',
+          lines_pct: 84.32,
+          branches_pct: 71.18,
+          statements_pct: 84.3,
+          functions_pct: 88.1,
+          files_count: 100,
+          missing_lines_count: 100,
+          top_uncovered_files: [],
+        },
+        {
+          name: 'ios',
+          lines_pct: 62.0,
+          branches_pct: null,
+          statements_pct: null,
+          functions_pct: null,
+          files_count: 50,
+          missing_lines_count: 50,
+          top_uncovered_files: [],
+        },
+      ],
+    };
+    const baseline = {
+      flags: [
+        {
+          name: 'ui',
+          lines_pct: 84.0,
+          branches_pct: 71.0,
+          statements_pct: 84.0,
+          functions_pct: 88.0,
+          files_count: 100,
+          missing_lines_count: 100,
+          top_uncovered_files: [],
+        },
+        {
+          name: 'ios',
+          lines_pct: 60.0,
+          branches_pct: null,
+          statements_pct: null,
+          functions_pct: null,
+          files_count: 50,
+          missing_lines_count: 50,
+          top_uncovered_files: [],
+        },
+      ],
+    };
+    const out = runFormat(current, baseline);
+    assert.ok(out.includes('| `ui` |'), 'ui flag row missing');
+    assert.ok(out.includes('| `ios` |'), 'ios flag row missing');
+    assert.ok(out.includes('▴ +'), 'positive delta arrow missing');
+  });
+
+  it('renders ❌ verdict when overall is below threshold', () => {
+    const out = runFormat({
+      flags: [
+        {
+          name: 'ui',
+          lines_pct: 50,
+          branches_pct: null,
+          statements_pct: null,
+          functions_pct: null,
+          files_count: 10,
+          missing_lines_count: 10,
+          top_uncovered_files: [],
+        },
+      ],
+    });
+    assert.ok(out.includes('## ❌ Coverage:'), 'fail verdict missing');
+    assert.ok(out.includes('70%'), 'threshold reference missing');
+  });
+
+  it('renders top-uncovered-files collapsible when files have missing lines', () => {
+    const out = runFormat({
+      flags: [
+        {
+          name: 'ui',
+          lines_pct: 84,
+          branches_pct: 71,
+          statements_pct: 84,
+          functions_pct: 88,
+          files_count: 2,
+          missing_lines_count: 50,
+          top_uncovered_files: [
+            { path: 'src/foo.ts', lines_pct: 20, missing: 40 },
+            { path: 'src/bar.ts', lines_pct: 80, missing: 10 },
+          ],
+        },
+      ],
+    });
+    assert.ok(out.includes('<details>'), 'collapsible missing');
+    assert.ok(out.includes('Top 2 files with most missing lines'));
+    assert.ok(out.includes('`src/foo.ts`'));
+    assert.ok(out.includes('40 lines'));
+  });
+
+  it('marks 🆕 for a flag without a baseline match', () => {
+    const out = runFormat(
+      {
+        flags: [
+          {
+            name: 'newsuite',
+            lines_pct: 90,
+            branches_pct: 80,
+            statements_pct: 90,
+            functions_pct: 95,
+            files_count: 5,
+            missing_lines_count: 5,
+            top_uncovered_files: [],
+          },
+        ],
+      },
+      { flags: [] },
+    );
+    assert.ok(out.includes('🆕'), 'new-flag marker missing');
+  });
+});

--- a/.github/scripts/sticky/format-quality.mjs
+++ b/.github/scripts/sticky/format-quality.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * format-quality.mjs -- aggregate lint/format/typecheck outcomes from a
+ * Tests workflow_run into the `heron-pr-quality` sticky.
+ *
+ * v1 design: reads a JSON dump of `gh api /repos/.../actions/runs/{id}/jobs`
+ * and formats a per-tool table. Each row: tool / status emoji /
+ * duration / link to the failing log line on failure.
+ *
+ * Why aggregate at the JOB level rather than re-run linters here:
+ * the Tests workflow already runs them (in the `format` job which calls
+ * biome / prettier / svelte-check / tsgo / oxlint / swiftlint /
+ * swiftformat / yamllint / taplo / ruff / actionlint / shellcheck).
+ * Re-running would double CI cost. The JOB outcome IS the signal --
+ * if the job is red, one or more linters in it failed. The reviewer
+ * clicks through to see the specific error.
+ *
+ * Future enhancement: have the format job upload structured per-tool
+ * output as an artifact and parse it here so the sticky can show
+ * "biome: 3 errors / svelte-check: 1 error" per tool rather than just
+ * "Lint + format: failed".
+ *
+ * Usage:
+ *   node format-quality.mjs <jobs.json> [--server-url URL] [--repo R] [--out path]
+ *
+ * jobs.json is the response body of `gh api /repos/{R}/actions/runs/{id}/jobs`.
+ */
+
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import { statusEmoji, humanDuration, table, verdictHeader, collapsibleSection } from './lib.mjs';
+
+const { values: opts, positionals } = parseArgs({
+  options: {
+    out: { type: 'string' },
+    'server-url': { type: 'string', default: 'https://github.com' },
+    repo: { type: 'string' },
+  },
+  allowPositionals: true,
+});
+
+const jobsPath = positionals[0];
+if (!jobsPath) {
+  console.error('Usage: format-quality.mjs <jobs.json> [--server-url URL] [--repo R] [--out path]');
+  process.exit(2);
+}
+
+const payload = JSON.parse(fs.readFileSync(jobsPath, 'utf8'));
+const jobs = payload.jobs || [];
+const REPO = opts.repo || process.env.GITHUB_REPOSITORY || '';
+const SERVER = opts['server-url'] || 'https://github.com';
+
+// Job names we treat as quality-checks. Keyword match -- robust to
+// renames as long as the canonical word stays.
+const QUALITY_KEYWORDS = [
+  'lint',
+  'format',
+  'typecheck',
+  'swiftlint',
+  'ktlint',
+  'ruff',
+  'shellcheck',
+  'actionlint',
+  'workflow',
+  'codeowners',
+  'required-check',
+  'pin',
+  'scorecard',
+  'zizmor',
+  'codeql',
+  'dependency',
+  'secret',
+  'audit',
+  'trufflehog',
+  'csp',
+];
+
+function isQualityJob(name) {
+  const lower = (name || '').toLowerCase();
+  return QUALITY_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+// Filter + dedup by name. The Tests workflow has separate `Lint + format`
+// + `TS -- typecheck + Vitest + coverage` jobs; both count.
+const qualityJobs = jobs.filter((j) => isQualityJob(j.name) && j.conclusion);
+
+// Sort by status (failures first) then by name.
+qualityJobs.sort((a, b) => {
+  const failedA = a.conclusion === 'failure' ? 0 : 1;
+  const failedB = b.conclusion === 'failure' ? 0 : 1;
+  if (failedA !== failedB) return failedA - failedB;
+  return (a.name || '').localeCompare(b.name || '');
+});
+
+const rows = qualityJobs.map((j) => {
+  const duration =
+    j.started_at && j.completed_at
+      ? new Date(j.completed_at).getTime() - new Date(j.started_at).getTime()
+      : 0;
+  const jobUrl =
+    j.html_url || (REPO ? `${SERVER}/${REPO}/actions/runs/${j.run_id}/job/${j.id}` : '#');
+  return {
+    Job: `[\`${j.name}\`](${jobUrl})`,
+    Status: `${statusEmoji(j.conclusion)} ${j.conclusion}`,
+    Duration: humanDuration(duration),
+  };
+});
+
+const failures = qualityJobs.filter((j) => j.conclusion === 'failure');
+const verdict = failures.length === 0 ? 'pass' : 'fail';
+const verdictText =
+  failures.length === 0
+    ? `Code quality: all checks pass`
+    : `Code quality: ${failures.length} failing check${failures.length === 1 ? '' : 's'}`;
+
+const lines = [];
+lines.push(verdictHeader(verdictText, verdict));
+lines.push('');
+
+if (qualityJobs.length === 0) {
+  lines.push(
+    '_No quality-related jobs found in the source workflow run. Update format-quality.mjs::QUALITY_KEYWORDS if a new lint job needs to be tracked._',
+  );
+} else {
+  lines.push(
+    table([{ label: 'Job' }, { label: 'Status' }, { label: 'Duration', align: 'right' }], rows),
+  );
+}
+
+// Failure details -- per failed job, list its failed STEPS (the
+// granular thing that broke). `gh api .../runs/{id}/jobs` returns
+// `steps` inline so we can render this without another API call.
+if (failures.length > 0) {
+  const detail = failures
+    .map((j) => {
+      const failedSteps = (j.steps || []).filter((s) => s.conclusion === 'failure');
+      const stepList = failedSteps.length
+        ? failedSteps.map((s) => `  - ${s.name} (step #${s.number})`).join('\n')
+        : '  - (no granular step info)';
+      return `**${j.name}**\n${stepList}`;
+    })
+    .join('\n\n');
+  lines.push('');
+  lines.push(
+    collapsibleSection(
+      `Failure details (${failures.length} job${failures.length === 1 ? '' : 's'})`,
+      detail,
+    ),
+  );
+}
+
+lines.push('');
+lines.push(
+  '<sub>aggregated from the Tests workflow_run jobs. For per-tool error details, expand the failing job log.</sub>',
+);
+
+const out = lines.join('\n') + '\n';
+if (opts.out) {
+  fs.writeFileSync(opts.out, out);
+  console.error(`Wrote ${out.length} bytes to ${opts.out}`);
+} else {
+  process.stdout.write(out);
+}

--- a/.github/scripts/sticky/format-quality.test.mjs
+++ b/.github/scripts/sticky/format-quality.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for format-quality.mjs.
+ * Run: node --test .github/scripts/sticky/format-quality.test.mjs
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = path.resolve('.github/scripts/sticky/format-quality.mjs');
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'format-q-'));
+}
+
+function runFormat(jobsPayload, opts = {}) {
+  const dir = makeTmp();
+  const jobsPath = path.join(dir, 'jobs.json');
+  fs.writeFileSync(jobsPath, JSON.stringify(jobsPayload));
+  const args = [SCRIPT, jobsPath];
+  if (opts.repo) args.push('--repo', opts.repo);
+  const out = execFileSync(process.execPath, args, { encoding: 'utf8' });
+  fs.rmSync(dir, { recursive: true, force: true });
+  return out;
+}
+
+describe('format-quality', () => {
+  it('renders pass verdict when all quality jobs succeed', () => {
+    const out = runFormat({
+      jobs: [
+        {
+          name: 'Lint + format (Python / Go / Kotlin / Shell / Ruby / YAML)',
+          conclusion: 'success',
+          started_at: '2026-05-21T17:00:00Z',
+          completed_at: '2026-05-21T17:02:00Z',
+        },
+        {
+          name: 'TS — typecheck + Vitest + coverage',
+          conclusion: 'success',
+          started_at: '2026-05-21T17:00:00Z',
+          completed_at: '2026-05-21T17:03:30Z',
+        },
+      ],
+    });
+    assert.ok(out.includes('## ✅ Code quality: all checks pass'), 'pass verdict missing');
+    assert.ok(out.includes('Lint + format'), 'lint job missing');
+    assert.ok(out.includes('TS — typecheck'), 'typecheck job missing');
+    assert.ok(out.includes('2m 0s'), 'duration missing');
+  });
+
+  it('renders fail verdict + failure-details collapsible when a job fails', () => {
+    const out = runFormat({
+      jobs: [
+        {
+          name: 'Lint + format (Python / Go / Kotlin / Shell / Ruby / YAML)',
+          conclusion: 'failure',
+          started_at: '2026-05-21T17:00:00Z',
+          completed_at: '2026-05-21T17:02:00Z',
+          steps: [
+            { name: 'yamllint', conclusion: 'failure', number: 5 },
+            { name: 'taplo format --check', conclusion: 'success', number: 6 },
+          ],
+        },
+        { name: 'TS — typecheck + Vitest + coverage', conclusion: 'success' },
+      ],
+    });
+    assert.ok(out.includes('## ❌ Code quality: 1 failing check'), 'fail verdict missing');
+    assert.ok(out.includes('<details>'), 'failure details missing');
+    assert.ok(out.includes('yamllint'), 'failed step name missing');
+    assert.ok(out.includes('step #5'), 'step number missing');
+  });
+
+  it('sorts failures first', () => {
+    const out = runFormat({
+      jobs: [
+        { name: 'A - lint', conclusion: 'success' },
+        { name: 'Z - lint', conclusion: 'failure' },
+        { name: 'M - lint', conclusion: 'success' },
+      ],
+    });
+    const zPos = out.indexOf('Z - lint');
+    const aPos = out.indexOf('A - lint');
+    const mPos = out.indexOf('M - lint');
+    assert.ok(zPos !== -1);
+    assert.ok(zPos < aPos, 'failure should appear before success');
+    assert.ok(zPos < mPos, 'failure should appear before all successes');
+  });
+
+  it('filters out non-quality jobs', () => {
+    const out = runFormat({
+      jobs: [
+        { name: 'iOS — XCTest + XCUITest + Snapshot', conclusion: 'success' }, // not in keywords
+        { name: 'Lint + format (...)', conclusion: 'success' },
+      ],
+    });
+    assert.ok(!out.includes('iOS'), 'iOS job should be filtered out');
+    assert.ok(out.includes('Lint + format'));
+  });
+
+  it('handles empty job list gracefully', () => {
+    const out = runFormat({ jobs: [] });
+    assert.ok(out.includes('No quality-related jobs found'));
+  });
+});

--- a/.github/scripts/sticky/lib.mjs
+++ b/.github/scripts/sticky/lib.mjs
@@ -1,0 +1,225 @@
+/**
+ * Shared formatting library for sticky-comment generators.
+ *
+ * Every `heron-pr-<type>` sticky uses these helpers so the comment
+ * vocabulary (emoji, table shape, delta arrows, collapsibles, footer)
+ * is identical across coverage / quality / visual / migrations / etc.
+ *
+ * No external deps -- pure Node stdlib. Importable from format-*.mjs
+ * scripts AND testable with vitest.
+ */
+
+/**
+ * Semaphore emoji vocabulary. Use these for every status indicator
+ * across sticky comments -- consistent vocabulary = lower cognitive
+ * load for reviewers scanning multiple stickies on one PR.
+ */
+export const EMOJI = Object.freeze({
+  pass: '✅',
+  fail: '❌',
+  warn: '⚠️',
+  improved: '🟢',
+  regressed: '🔴',
+  neutral: '🟡',
+  skip: '⬜',
+  new: '🆕',
+  removed: '🗑️',
+  building: '🛠️',
+  queued: '⏳',
+  cancelled: '🚫',
+  question: '❓',
+});
+
+/**
+ * Map a CI conclusion / status to the semaphore emoji.
+ * Falls through to the question-mark for unknown states so the comment
+ * never claims a value it doesn't know.
+ */
+export function statusEmoji(state) {
+  switch ((state || '').toLowerCase()) {
+    case 'success':
+    case 'pass':
+    case 'passed':
+    case 'completed-success':
+      return EMOJI.pass;
+    case 'failure':
+    case 'fail':
+    case 'failed':
+    case 'completed-failure':
+      return EMOJI.fail;
+    case 'cancelled':
+    case 'canceled':
+      return EMOJI.cancelled;
+    case 'skipped':
+    case 'skip':
+      return EMOJI.skip;
+    case 'neutral':
+      return EMOJI.neutral;
+    case 'in_progress':
+    case 'queued':
+    case 'pending':
+    case 'waiting':
+      return EMOJI.queued;
+    default:
+      return EMOJI.question;
+  }
+}
+
+/**
+ * Format a numeric delta as `▴ +N.NN%` (improved) / `▾ -N.NN%` (regressed) /
+ * `= 0.00%` (unchanged). Used in coverage / bundle / perf deltas.
+ *
+ * Threshold is the minimum absolute delta considered "interesting" --
+ * smaller values render as `=` to avoid noisy reports.
+ *
+ * @param {number} base
+ * @param {number} head
+ * @param {{ threshold?: number, suffix?: string, decimals?: number }} [opts]
+ * @returns {string}
+ */
+export function deltaCell(base, head, opts = {}) {
+  const threshold = opts.threshold ?? 0.05;
+  const suffix = opts.suffix ?? '%';
+  const decimals = opts.decimals ?? 2;
+  if (typeof base !== 'number' || Number.isNaN(base) || base === null)
+    return `🆕 ${formatNum(head, decimals)}${suffix}`;
+  if (typeof head !== 'number' || Number.isNaN(head)) return `🗑️ (gone)`;
+  const delta = head - base;
+  const abs = Math.abs(delta);
+  if (abs < threshold) return `= 0.00${suffix}`;
+  if (delta > 0) return `▴ +${formatNum(delta, decimals)}${suffix}`;
+  return `▾ ${formatNum(delta, decimals)}${suffix}`;
+}
+
+function formatNum(n, decimals) {
+  if (n === 0) return '0';
+  return n.toFixed(decimals);
+}
+
+/**
+ * Render a horizontal progress bar made of █ and ░. Used for inline
+ * coverage / bundle / perf percentages where the eye benefits from a
+ * proportional visualisation alongside the number.
+ *
+ * @param {number} pct -- 0..100
+ * @param {number} [width] -- character width of the bar (default 16)
+ */
+export function pctBar(pct, width = 16) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * width);
+  return '█'.repeat(filled) + '░'.repeat(width - filled);
+}
+
+/**
+ * Wrap content in a `<details>` collapsible. Used for verbose data
+ * (file lists, full error traces, per-route breakdown) that shouldn't
+ * dominate the comment but should be reachable in one click.
+ *
+ * @param {string} summary -- visible text on the collapsed row
+ * @param {string} body -- markdown content shown when expanded
+ * @returns {string}
+ */
+export function collapsibleSection(summary, body) {
+  return `<details><summary>${summary}</summary>\n\n${body}\n\n</details>`;
+}
+
+/**
+ * Wrap text as a keyboard / monospace span. Use for SHA, file paths,
+ * code snippets inside table cells.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function kbd(text) {
+  return `\`${text}\``;
+}
+
+/**
+ * Standard footer line. The composite Action appends this automatically;
+ * exposed here for tests + for stickies that need to override.
+ *
+ * @param {{ sha: string, repo: string, timestamp?: string, docsUrl?: string }} opts
+ * @returns {string}
+ */
+export function footer({ sha, repo, timestamp, docsUrl }) {
+  const ts = timestamp || new Date().toISOString().replace('T', ' ').slice(0, 16);
+  const docs = docsUrl || `https://github.com/${repo}/blob/main/docs/CI.md`;
+  const shortSha = (sha || '').slice(0, 7);
+  return `_Updated ${ts} UTC -- commit [\`${shortSha}\`](https://github.com/${repo}/commit/${sha}) -- [CI docs](${docs})_`;
+}
+
+/**
+ * Compose a markdown table from rows + columns. Each row is an object
+ * keyed by column name. Used to keep table shape consistent across
+ * stickies (header / separator / right-aligned numerics).
+ *
+ * @param {Array<{label: string, align?: 'left'|'right'|'center'}>} columns
+ * @param {Array<Record<string, string>>} rows
+ * @returns {string}
+ */
+export function table(columns, rows) {
+  if (!rows.length) return '_(no rows)_';
+  const headerRow = `| ${columns.map((c) => c.label).join(' | ')} |`;
+  const sepRow = `|${columns
+    .map((c) => {
+      switch (c.align) {
+        case 'right':
+          return '--:';
+        case 'center':
+          return ':-:';
+        default:
+          return '---';
+      }
+    })
+    .map((s) => `${s}|`)
+    .join('')}`;
+  const dataRows = rows.map((row) => `| ${columns.map((c) => row[c.label] ?? '').join(' | ')} |`);
+  return [headerRow, sepRow, ...dataRows].join('\n');
+}
+
+/**
+ * One-line verdict header for a sticky. Always the first content line
+ * (after the marker). Examples:
+ *   `## ✅ Coverage: 84.32% (▴ +0.18%)`
+ *   `## ❌ Lint: 3 errors across 2 tools`
+ *
+ * @param {string} title
+ * @param {string} state -- canonical state name (see statusEmoji)
+ * @param {string} [subline] -- optional context after the title
+ * @returns {string}
+ */
+export function verdictHeader(title, state, subline) {
+  const head = `## ${statusEmoji(state)} ${title}`;
+  return subline ? `${head}\n\n${subline}` : head;
+}
+
+/**
+ * Convert bytes to a human-readable size. Used for bundle / file-size
+ * stickies.
+ *
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function humanBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  if (!bytes || Number.isNaN(bytes)) return '--';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(units.length - 1, Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024)));
+  return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
+}
+
+/**
+ * Format a duration in milliseconds as `Nm Ms` or `Ns`. For per-job /
+ * per-step timing breakdowns.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+export function humanDuration(ms) {
+  if (!ms || Number.isNaN(ms)) return '--';
+  const total = Math.round(ms / 1000);
+  if (total < 60) return `${total}s`;
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}m ${s}s`;
+}

--- a/.github/scripts/sticky/lib.test.mjs
+++ b/.github/scripts/sticky/lib.test.mjs
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the sticky-comment shared library.
+ *
+ * Uses Node's built-in test runner so we don't need to register
+ * .github/scripts as a vitest project (the repo's root vitest.config.ts
+ * is a tripwire that refuses root-level invocation).
+ *
+ * Run via:  node --test .github/scripts/sticky/lib.test.mjs
+ * In CI:    the format-comment workflow runs this before composing the
+ *           sticky body, so broken helpers never reach a PR comment.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EMOJI,
+  statusEmoji,
+  deltaCell,
+  pctBar,
+  collapsibleSection,
+  kbd,
+  footer,
+  table,
+  verdictHeader,
+  humanBytes,
+  humanDuration,
+} from './lib.mjs';
+
+describe('statusEmoji', () => {
+  const cases = [
+    ['success', EMOJI.pass],
+    ['pass', EMOJI.pass],
+    ['Passed', EMOJI.pass],
+    ['failure', EMOJI.fail],
+    ['fail', EMOJI.fail],
+    ['cancelled', EMOJI.cancelled],
+    ['canceled', EMOJI.cancelled],
+    ['skipped', EMOJI.skip],
+    ['skip', EMOJI.skip],
+    ['neutral', EMOJI.neutral],
+    ['in_progress', EMOJI.queued],
+    ['queued', EMOJI.queued],
+    ['something-unknown', EMOJI.question],
+    [undefined, EMOJI.question],
+    [null, EMOJI.question],
+    ['', EMOJI.question],
+  ];
+  for (const [input, expected] of cases) {
+    it(`maps ${JSON.stringify(input)} -> ${expected}`, () => {
+      assert.equal(statusEmoji(input), expected);
+    });
+  }
+});
+
+describe('deltaCell', () => {
+  it('reports improvement with up arrow + sign', () => {
+    assert.ok(deltaCell(80, 84.32).includes('▴ +'));
+  });
+  it('reports regression with down arrow -', () => {
+    assert.ok(deltaCell(84, 80).includes('▾ -'));
+  });
+  it('reports unchanged with =', () => {
+    assert.equal(deltaCell(80, 80), '= 0.00%');
+  });
+  it('respects threshold (small deltas render as =)', () => {
+    assert.equal(deltaCell(80, 80.01), '= 0.00%');
+  });
+  it('renders new flag when base is missing', () => {
+    assert.ok(deltaCell(null, 80).includes('🆕'));
+    assert.ok(deltaCell(undefined, 80).includes('🆕'));
+  });
+  it('renders removed flag when head is missing', () => {
+    assert.ok(deltaCell(80, NaN).includes('🗑️'));
+  });
+  it('honors custom suffix', () => {
+    assert.ok(deltaCell(100, 200, { suffix: ' KB', threshold: 1 }).includes('KB'));
+  });
+});
+
+describe('pctBar', () => {
+  it('renders 0% as all-empty', () => {
+    assert.equal(pctBar(0, 10), '░'.repeat(10));
+  });
+  it('renders 100% as all-filled', () => {
+    assert.equal(pctBar(100, 10), '█'.repeat(10));
+  });
+  it('renders 50% as half-and-half', () => {
+    assert.equal(pctBar(50, 10), '█████░░░░░');
+  });
+  it('clamps negative values', () => {
+    assert.equal(pctBar(-50, 10), '░'.repeat(10));
+  });
+  it('clamps values > 100', () => {
+    assert.equal(pctBar(150, 10), '█'.repeat(10));
+  });
+});
+
+describe('collapsibleSection', () => {
+  it('produces a valid <details> block', () => {
+    const out = collapsibleSection('Top 5 missing lines', 'file1\nfile2');
+    assert.ok(out.includes('<details>'));
+    assert.ok(out.includes('<summary>Top 5 missing lines</summary>'));
+    assert.ok(out.includes('file1\nfile2'));
+    assert.ok(out.includes('</details>'));
+  });
+});
+
+describe('kbd', () => {
+  it('wraps in backticks', () => {
+    assert.equal(kbd('abc123'), '`abc123`');
+  });
+});
+
+describe('footer', () => {
+  it('includes SHA + repo + docs URL', () => {
+    const f = footer({
+      sha: 'abcdef1234567890',
+      repo: 'kaelys-js/heron',
+      timestamp: '2026-05-21 17:50',
+    });
+    assert.ok(f.includes('`abcdef1`'));
+    assert.ok(f.includes('kaelys-js/heron'));
+    assert.ok(f.includes('docs/CI.md'));
+    assert.ok(f.includes('2026-05-21'));
+  });
+});
+
+describe('table', () => {
+  it('renders empty rows', () => {
+    assert.equal(table([{ label: 'X' }], []), '_(no rows)_');
+  });
+  it('renders a 2-column table', () => {
+    const out = table(
+      [{ label: 'Path' }, { label: 'Size', align: 'right' }],
+      [{ Path: 'foo.js', Size: '10 KB' }],
+    );
+    assert.ok(out.includes('| Path | Size |'));
+    assert.ok(out.includes('|---|--:|'));
+    assert.ok(out.includes('| foo.js | 10 KB |'));
+  });
+  it('honors center alignment', () => {
+    const out = table([{ label: 'X', align: 'center' }], [{ X: 'a' }]);
+    assert.ok(out.includes('|:-:|'));
+  });
+});
+
+describe('verdictHeader', () => {
+  it('builds a top-line H2 with emoji', () => {
+    assert.equal(verdictHeader('Coverage: 84%', 'success'), `## ${EMOJI.pass} Coverage: 84%`);
+  });
+  it('appends an optional subline', () => {
+    const out = verdictHeader('Coverage: 84%', 'success', '+0.18% vs base');
+    assert.ok(out.includes('## ✅ Coverage: 84%'));
+    assert.ok(out.includes('+0.18% vs base'));
+  });
+});
+
+describe('humanBytes', () => {
+  const cases = [
+    [0, '0 B'],
+    [512, '512 B'],
+    [1024, '1.00 KB'],
+    [1536, '1.50 KB'],
+    [1048576, '1.00 MB'],
+    [5242880, '5.00 MB'],
+  ];
+  for (const [input, expected] of cases) {
+    it(`formats ${input} as ${expected}`, () => {
+      assert.equal(humanBytes(input), expected);
+    });
+  }
+});
+
+describe('humanDuration', () => {
+  const cases = [
+    [500, '1s'],
+    [1000, '1s'],
+    [59000, '59s'],
+    [60000, '1m 0s'],
+    [90000, '1m 30s'],
+    [3600000, '60m 0s'],
+  ];
+  for (const [input, expected] of cases) {
+    it(`formats ${input}ms as ${expected}`, () => {
+      assert.equal(humanDuration(input), expected);
+    });
+  }
+});

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,211 @@
+name: PR coverage comment
+# Posts the `heron-pr-coverage` sticky comment on every PR. Runs AFTER
+# Tests completes via `workflow_run` so we have actual coverage artifacts
+# to read, not a partial / running snapshot.
+#
+# Auto-discovery design: the scanner walks the working tree for any
+# coverage file in a recognised format (Istanbul / lcov / cobertura /
+# clover / xcov). Add a new test suite that emits coverage in any of
+# those formats and it shows up in the sticky on the next PR with zero
+# config edits.
+#
+# Baseline source: the most recent COMPLETED Tests workflow run on
+# `main` -- artifact `coverage-baseline` (uploaded by this same workflow
+# on main-push). When that artifact doesn't exist (cold start) the
+# sticky shows current numbers only + a `🆕` marker per flag.
+#
+# Permissions:
+#   actions: read     -- query source run + download artifacts
+#   pull-requests: write -- post / edit sticky
+#   contents: read    -- read the scripts from main (no checkout of PR head)
+#
+# Why workflow_run vs pull_request_target: see pr-ci-summary.yml header
+# for the long-form rationale. Short version: workflow_run gives us
+# write permissions without the branch-isolation footgun of
+# pull_request_target.
+
+on: # zizmor: ignore[dangerous-triggers]
+  # SAFETY: workflow_run inherits write secrets, but this workflow:
+  #   1. Never checks out the PR head (no actions/checkout of PR ref --
+  #      the only checkout pulls main, which is trusted)
+  #   2. Composes the sticky body via this repo's own scripts run
+  #      against the downloaded artifact data, never against PR text
+  #   3. Calls only `gh pr comment` / `gh pr edit` via the composite
+  #      action -- argv-passing, no shell-interpolated PR content
+  workflow_run:
+    workflows: ['Tests']
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: coverage-comment-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Post heron-pr-coverage sticky
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+      contents: read
+    # Only act on success / failure (skip cancelled). Both pass + fail
+    # runs get a comment so the reviewer sees the current state, not
+    # last-known-good.
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout main (for the scripts; never the PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Download coverage-ts artifact from the source run
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v5
+        with:
+          name: coverage-ts
+          path: ui/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true # ts job may have skipped (path filter)
+
+      - name: Download coverage-ios artifact from the source run
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v5
+        with:
+          name: coverage-ios
+          path: ui/ios/App/fastlane/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true # ios job may have skipped
+
+      - name: Discover coverage
+        run: node .github/scripts/sticky/discover-coverage.mjs --out coverage.json
+
+      - name: Download coverage baseline from main
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Find most recent COMPLETED Tests run on main.
+          LATEST=$(gh api "repos/$GH_REPO/actions/workflows/test.yml/runs?branch=main&status=completed&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -z "$LATEST" ]; then
+            echo "no_baseline=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Try to fetch the baseline artifact. continue-on-error
+          # equivalent: don't fail this step if the artifact doesn't exist.
+          if gh run download "$LATEST" --repo "$GH_REPO" --name coverage-baseline --dir baseline 2>/dev/null; then
+            if [ -f baseline/coverage.json ]; then
+              echo "no_baseline=false" >>"$GITHUB_OUTPUT"
+              echo "::notice::Using baseline from run $LATEST."
+            else
+              echo "no_baseline=true" >>"$GITHUB_OUTPUT"
+            fi
+          else
+            echo "no_baseline=true" >>"$GITHUB_OUTPUT"
+            echo "::notice::No baseline artifact on main yet (cold start). Sticky will show current only."
+          fi
+
+      - name: Format coverage sticky body
+        run: |
+          if [ "${{ steps.baseline.outputs.no_baseline }}" = "true" ]; then
+            node .github/scripts/sticky/format-coverage.mjs coverage.json --out body.md
+          else
+            node .github/scripts/sticky/format-coverage.mjs coverage.json baseline/coverage.json --out body.md
+          fi
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          NUM=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH" || true)
+          if [ -z "$NUM" ]; then
+            NUM=$(gh pr list --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "$NUM" ]; then
+            echo "::notice::No PR found for $HEAD_BRANCH. Nothing to comment on."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          fi
+          echo "number=$NUM" >>"$GITHUB_OUTPUT"
+
+      - name: Post sticky comment
+        if: steps.pr.outputs.skip != 'true'
+        uses: ./.github/actions/sticky-comment
+        with:
+          marker: heron-pr-coverage
+          body-path: body.md
+          pr-number: ${{ steps.pr.outputs.number }}
+
+  # Upload baseline coverage on main pushes so the next PR has something
+  # to diff against. Stored as artifact `coverage-baseline` with stable
+  # name (overwrites each main push).
+  upload-baseline:
+    name: Upload baseline coverage on main
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      contents: read
+    if: |
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Download coverage-ts artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v5
+        with:
+          name: coverage-ts
+          path: ui/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download coverage-ios artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v5
+        with:
+          name: coverage-ios
+          path: ui/ios/App/fastlane/coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Discover + upload baseline
+        run: node .github/scripts/sticky/discover-coverage.mjs --out coverage.json
+
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-baseline
+          path: coverage.json
+          retention-days: 90
+          overwrite: true

--- a/.github/workflows/pr-ci-summary.yml
+++ b/.github/workflows/pr-ci-summary.yml
@@ -138,11 +138,16 @@ jobs:
             STATUS="Failed"
           fi
 
-          # Compose the sticky comment. HTML-comment marker on the
-          # FIRST and LAST line lets the lookup-and-update step replace
-          # the whole block on the next push instead of stacking comments.
+          # Compose the sticky comment body. The composite sticky-comment
+          # action adds its own `<!-- heron-pr-ci-status -->` marker on
+          # the first line + a footer at the bottom -- so this template
+          # writes JUST the body content.
+          #
+          # Two files written:
+          #   /tmp/comment.md           -- legacy "with marker" form, kept
+          #                                for the step summary at the end
+          #   /tmp/comment-noheader.md  -- body-only, passed to the composite
           {
-            echo "<!-- heron-pr-ci-status -->"
             echo "## 🚦 Heron CI"
             echo ""
             echo "| Status | Commit | Run | Branch |"
@@ -161,7 +166,15 @@ jobs:
               echo "> Open the [run]($RUN_URL) for the full log + failing-step annotations."
               echo ""
             fi
-            echo "_Auto-posted by [pr-ci-summary.yml]($SERVER_URL/$GH_REPO/blob/main/.github/workflows/pr-ci-summary.yml) — updates in place on each push._"
+            echo "_Auto-posted by [pr-ci-summary.yml]($SERVER_URL/$GH_REPO/blob/main/.github/workflows/pr-ci-summary.yml) -- updates in place on each push._"
+          } > /tmp/comment-noheader.md
+
+          # Legacy `comment.md` with marker -- used by the step-summary
+          # block at the bottom of the workflow for human-readable
+          # archival in the Actions UI. Not posted to the PR.
+          {
+            echo "<!-- heron-pr-ci-status -->"
+            cat /tmp/comment-noheader.md
             echo "<!-- /heron-pr-ci-status -->"
           } > /tmp/comment.md
 
@@ -173,36 +186,39 @@ jobs:
             echo "<!-- CI-STATUS-MARKER-END -->"
           } > /tmp/marker.md
 
-      - name: Post or update sticky comment + refresh body marker
+      - name: Checkout main (for the composite sticky-comment action)
+        if: steps.compose.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Post or update sticky CI status comment
+        if: steps.compose.outputs.skip != 'true'
+        uses: ./.github/actions/sticky-comment
+        with:
+          marker: heron-pr-ci-status
+          # body-path is the marker-less compose output -- the composite
+          # adds its own marker + footer.
+          body-path: /tmp/comment-noheader.md
+          pr-number: ${{ steps.compose.outputs.pr_num }}
+          # Suppress the composite footer since this comment composes its
+          # own attribution line via the existing pr-ci-summary.yml template.
+          footer: 'false'
+
+      - name: Refresh PR description CI-STATUS marker block
         if: steps.compose.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           PR_NUM: ${{ steps.compose.outputs.pr_num }}
-          SHORT_SHA: ${{ steps.compose.outputs.short_sha }}
         run: |
           set -euo pipefail
-
-          # 1. Find existing sticky comment by marker.
-          EXISTING_ID=$(gh api "repos/$GH_REPO/issues/$PR_NUM/comments" --paginate \
-            --jq '[.[] | select(.body | contains("<!-- heron-pr-ci-status -->")) | .id] | .[0] // empty')
-
-          if [ -n "$EXISTING_ID" ]; then
-            # Update in place. gh api PATCH on the comment id.
-            # `--raw-field body=@<path>` reads the body straight from
-            # the file -- no need to cat-and-encode via jq.
-            gh api "repos/$GH_REPO/issues/comments/$EXISTING_ID" \
-              --method PATCH \
-              --raw-field body=@/tmp/comment.md > /dev/null
-            echo "::notice::Updated sticky CI comment on PR #$PR_NUM (id $EXISTING_ID, sha $SHORT_SHA)."
-          else
-            # First comment for this PR. Create.
-            gh pr comment "$PR_NUM" --body-file /tmp/comment.md
-            echo "::notice::Created sticky CI comment on PR #$PR_NUM (sha $SHORT_SHA)."
-          fi
-
-          # 2. Refresh PR description marker block. Fetch the current
-          # body, replace (or prepend) the one-line marker.
+          # Refresh PR description marker block. Fetch the current body,
+          # replace (or prepend) the one-line marker. This is separate
+          # from the sticky comment -- it's a compact one-liner in the
+          # PR description so the status is visible at-a-glance without
+          # scrolling to the comments.
           BODY=$(gh pr view "$PR_NUM" --json body --jq '.body // ""')
           if printf '%s' "$BODY" | grep -q '<!-- CI-STATUS-MARKER-START -->'; then
             UPDATED=$(printf '%s' "$BODY" | perl -0777 -pe '
@@ -217,7 +233,7 @@ jobs:
           printf '%s' "$UPDATED" | gh pr edit "$PR_NUM" --body-file -
           echo "::notice::Refreshed CI-STATUS marker in PR #$PR_NUM description."
 
-          # 3. Step summary for the action's own run.
+          # Step summary for the action's own run.
           {
             echo "### Posted CI summary to PR #$PR_NUM"
             echo ""

--- a/.github/workflows/quality-comment.yml
+++ b/.github/workflows/quality-comment.yml
@@ -1,0 +1,92 @@
+name: PR quality comment
+# Posts the `heron-pr-quality` sticky comment on every PR. Triggered by
+# Tests completing -- reads the Tests run's jobs via the GH API and
+# aggregates lint / format / typecheck outcomes into one table.
+#
+# Auto-discovery via keyword match (see format-quality.mjs::QUALITY_KEYWORDS):
+# add a new lint workflow with `lint`, `format`, or any of the matching
+# keywords in the job name and it shows up here without code edits.
+
+on: # zizmor: ignore[dangerous-triggers]
+  # SAFETY: same as coverage-comment.yml + pr-ci-summary.yml -- this
+  # workflow:
+  #   1. Never checks out the PR head; only reads main + queries the GH
+  #      API for job metadata (no PR-controlled content reaches a shell).
+  #   2. Calls only the composite sticky-comment action, which is also
+  #      argv-safe.
+  workflow_run:
+    workflows: ['Tests']
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: quality-comment-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Post heron-pr-quality sticky
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      pull-requests: write
+      contents: read
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout main (for the scripts; never the PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Fetch source-run jobs from GH API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GH_REPO/actions/runs/$RUN_ID/jobs" --paginate \
+            --slurp \
+            --jq '{jobs: (map(.jobs) | add)}' > jobs.json
+          echo "::notice::Fetched $(jq '.jobs | length' jobs.json) jobs for run $RUN_ID."
+
+      - name: Format quality sticky body
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: node .github/scripts/sticky/format-quality.mjs jobs.json --repo "$GH_REPO" --out body.md
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          NUM=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH" || true)
+          if [ -z "$NUM" ]; then
+            NUM=$(gh pr list --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          fi
+          if [ -z "$NUM" ]; then
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          fi
+          echo "number=$NUM" >>"$GITHUB_OUTPUT"
+
+      - name: Post sticky comment
+        if: steps.pr.outputs.skip != 'true'
+        uses: ./.github/actions/sticky-comment
+        with:
+          marker: heron-pr-quality
+          body-path: body.md
+          pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -589,6 +589,21 @@ jobs:
             ui/test-results/
           retention-days: 14
 
+      # Upload coverage as a workflow artifact so the `coverage-comment.yml`
+      # sticky-comment workflow (triggered by workflow_run after this run
+      # completes) can download + scan it. Codecov uploads the same file
+      # for its own sunburst; this artifact is for the in-repo sticky.
+      - name: Upload TS coverage artifact for sticky-comment workflow
+        if: needs.changes.outputs.ts == 'true' && always() && hashFiles('ui/coverage/lcov.info') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-ts
+          path: |
+            ui/coverage/lcov.info
+            ui/coverage/coverage-summary.json
+          retention-days: 14
+          if-no-files-found: warn
+
   # ─────────────────────────────────────────────────────────────────
   # iOS -- Fastlane test_ci on macOS-15 (Xcode 16, Swift 5.9+)
   # ─────────────────────────────────────────────────────────────────
@@ -787,6 +802,16 @@ jobs:
           fail_ci_if_error: true
           use_oidc: true
           verbose: true
+
+      # Sibling of the ts-job upload, for the heron-pr-coverage sticky.
+      - name: Upload iOS coverage artifact for sticky-comment workflow
+        if: needs.changes.outputs.ios == 'true' && always() && hashFiles('ui/ios/App/fastlane/coverage/cobertura.xml') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-ios
+          path: ui/ios/App/fastlane/coverage/cobertura.xml
+          retention-days: 14
+          if-no-files-found: warn
 
   # ─────────────────────────────────────────────────────────────────
   # Multi-language format / lint -- one job covers every non-JS surface


### PR DESCRIPTION
## Summary

- New composite Action `.github/actions/sticky-comment/` wrapping `marocchino/sticky-pull-request-comment@7737449` (v2.9.4, SHA-pinned). One marker convention (`heron-pr-<type>`), one footer style, one place to bump the pin.
- New shared formatting library `.github/scripts/sticky/lib.mjs` — emoji vocabulary, delta arrows, progress bars, tables, collapsibles, footer. 48 node:test cases.
- New sticky bot 1: **`heron-pr-coverage`** — auto-discovers Istanbul / lcov / cobertura / clover / xcov coverage from any path in the working tree. New test suite → coverage shows up with zero config.
- New sticky bot 2: **`heron-pr-quality`** — aggregates lint / format / typecheck job outcomes from the Tests workflow_run into one table.
- Refactor: `pr-ci-summary.yml` now uses the composite (canary).
- `test.yml`: upload coverage as `coverage-ts` / `coverage-ios` artifacts so the sticky workflow can read them.

## Motivation

You asked for beautiful sticky comments matching CodeRabbit / Codecov / Vercel polish — and specifically for test coverage that "shouldn't need to update if new testing sources are added." This PR builds the framework that future sticky bots (visual, migrations, bundle, perf, security, etc. — coming in PR γ) all plug into via one composite Action + one formatting library.

Auto-discovery means: drop a coverage file in any of the 5 recognised formats anywhere in the tree, and it shows up in the next PR's `heron-pr-coverage` sticky. No `.github/coverage-sources.yml` to maintain, no per-workspace registration.

## What lands per sticky type

| Marker | Source workflow | What it shows |
|---|---|---|
| `heron-pr-ci-status` | `pr-ci-summary.yml` (refactored) | Pass/fail + per-job breakdown table |
| `heron-pr-coverage` | `coverage-comment.yml` (new) | Per-flag lines/branches/statements/functions + delta vs main + top-uncovered-files collapsible |
| `heron-pr-quality` | `quality-comment.yml` (new) | Per-job lint/format/typecheck status table + failure-details collapsible |

## Layout DNA (consistent across all stickies)

- Header line: `## ✅ Coverage: 84.32% (▴ +0.18% vs base)` (or `## ❌` on fail)
- 3-column delta tables with `▴ +N%` / `▾ -N%` arrows
- `✅ ❌ ⚠️ 🟢 🔴 🟡 ⬜ 🆕 🗑️ ⏳ 🚫 ❓` semaphore emoji vocabulary
- `<details>` collapsibles for verbose data
- Standard footer with timestamp + short SHA link + CI docs link

## Test plan

- [x] `node --test .github/scripts/sticky/*.test.mjs` — 66 cases pass (lib 48, discover 7, format-coverage 6, format-quality 5)
- [x] `actionlint -shellcheck=shellcheck .github/workflows/*.yml` clean
- [x] Local pre-push gauntlet passes (engine-pin, typecheck, vitest, format-check, swiftlint, ktlint, ruff, actionlint, per-commit-conventional, file-size, path-length, file-extensions, pr-title-budget)
- [ ] CI green on this PR (the 3 new bots will post stickies on the PR itself — meta validation)
- [ ] After merge: workflow_run on main uploads `coverage-baseline` artifact for the next PR's delta arrows

## Notes

- This PR exceeds the 2000-LOC budget (≈ 2100 lines). Composite + lib + first 2 bots need to land together to be useful — adding `oversize-ok` label.
- **No Copilot anything** (per direction).
- PR β of 5 in audit cycle 4. PR γ adds 10 more sticky types on top of this framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated coverage and quality metrics now automatically post to pull requests as sticky comments
  * Coverage reports track baseline comparisons and display per-flag coverage percentages with visual progress bars
  * Quality job summaries show test execution status and duration with failure details available in collapsible sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->