### PR TITLE
fix(ci): apply-user-features 3-bug + Pages enable + PAT-scope ux

### DIFF
--- a/.github/workflows/maintain-features.yml
+++ b/.github/workflows/maintain-features.yml
@@ -91,6 +91,18 @@ jobs:
         # automation possible until that API ships.
         run: pnpm og:generate
 
+      - name: Upload social preview PNG as artifact
+        # Persists ui/static/og/default.png from the ephemeral runner
+        # so the maintainer can download it from the Actions run page
+        # + drag into Settings -> Social preview. 90-day retention is
+        # the GitHub default; enough lead time across rebrands.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: social-preview-png
+          path: ui/static/og/default.png
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Reconcile
         env:
           GH_TOKEN: ${{ secrets.GH_USER_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maintain-features.yml
+++ b/.github/workflows/maintain-features.yml
@@ -78,6 +78,19 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          install_deps: "true"
+
+      - name: Regenerate social preview PNG
+        # Keeps ui/static/og/default.png fresh so the maintainer can
+        # upload it via Settings -> General -> Social preview at any
+        # time and pick up the latest brand. GitHub has no public API
+        # to push the social preview image; this is the cleanest
+        # automation possible until that API ships.
+        run: pnpm og:generate
+
       - name: Reconcile
         env:
           GH_TOKEN: ${{ secrets.GH_USER_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-expiry-check.yml
+++ b/.github/workflows/secret-expiry-check.yml
@@ -9,6 +9,9 @@ name: Secret expiry check
 #   - APPLE_DEVELOPER_ID_CERT_P12 (Mac/iOS distribution cert, 1y TTL)
 #   - APP_STORE_CONNECT_API_KEY (ASC API key, rotation-by-policy)
 #   - IOS_PROVISIONING_PROFILE (provisioning profile, 1y TTL)
+#   - GH_USER_PAT (fine-grained PAT, 90d TTL -- probes via the
+#     `github-authentication-token-expiration` response header that
+#     GitHub returns on every PAT-authenticated REST call)
 #   - (G18 forthcoming) AZURE_TRUSTED_SIGNING_CERT
 #
 # Self-healing: if all certs are >30d from expiry, no issue is opened.
@@ -142,3 +145,105 @@ jobs:
               labels: ['security', 'release-blocker'],
             });
             core.info(`Opened expiry-warning issue with ${warnings.length} item(s)`);
+
+  check-gh-user-pat:
+    name: GH_USER_PAT expiry probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+    if: github.repository_owner == 'heron' || github.repository_owner == 'kaelys-js'
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Probe PAT + read expiration header
+        env:
+          PAT: ${{ secrets.GH_USER_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PAT" ]; then
+            echo "::notice::GH_USER_PAT not set -- skipping expiry probe"
+            exit 0
+          fi
+          # GitHub returns the PAT's expiration in the
+          # `github-authentication-token-expiration` response header on
+          # any PAT-authenticated REST call. Format: ISO-8601-ish,
+          # e.g. "2026-08-19 12:34:56 UTC". We probe the cheap
+          # /user endpoint (read-only, no rate-limit pressure).
+          HDRS=$(curl -sS -D - -o /dev/null \
+            -H "Authorization: Bearer $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)
+          EXPIRY=$(printf '%s' "$HDRS" \
+            | grep -i '^github-authentication-token-expiration:' \
+            | sed -E 's/^[^:]+:[[:space:]]*//; s/\r$//' \
+            | head -1)
+          if [ -z "$EXPIRY" ]; then
+            echo "::warning::PAT probe returned no expiration header. PAT may be invalid OR may be a classic (non-expiring) PAT."
+            echo "PAT_DAYS=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          # Parse the timestamp (GNU date on ubuntu accepts it directly).
+          EXPIRY_EPOCH=$(date -d "$EXPIRY" "+%s")
+          NOW_EPOCH=$(date "+%s")
+          DAYS=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+          echo "GH_USER_PAT expires in $DAYS days ($EXPIRY)"
+          echo "PAT_DAYS=$DAYS" >> "$GITHUB_ENV"
+          echo "PAT_EXPIRY=$EXPIRY" >> "$GITHUB_ENV"
+      - name: Open issue if PAT expires in <30 days
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const days = parseInt(process.env.PAT_DAYS || '', 10);
+            const expiry = process.env.PAT_EXPIRY || '(unknown)';
+            if (Number.isNaN(days)) {
+              core.info('PAT_DAYS not set -- nothing to do');
+              return;
+            }
+            if (days >= 30) {
+              core.info(`✓ GH_USER_PAT >30 days from expiry (${days}d, ${expiry})`);
+              return;
+            }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            // Dedup: don't open a second issue if one is already open.
+            const existing = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'security,release-blocker',
+            });
+            const already = existing.data.find((i) => /GH_USER_PAT/.test(i.title));
+            const title = `🔐 GH_USER_PAT rotation needed in ${days} days (${expiry})`;
+            const body = [
+              `The \`GH_USER_PAT\` secret expires in **${days} days** (\`${expiry}\`).`,
+              ``,
+              `When it expires, \`maintain-user-features.yml\` will start no-op-ing with a notice + the pinned Roadmap issue / discussions / Project v2 / profile README will stop reconciling.`,
+              ``,
+              `### Rotation procedure`,
+              ``,
+              `1. <https://github.com/settings/personal-access-tokens> -> find the entry named \`heron-maintain-user-features\` -> Regenerate.`,
+              `2. New expiration: 90 days. Keep the SAME repository access (\`kaelys-js/heron\` + \`kaelys-js/kaelys-js\`) and the SAME scopes (Contents R/W, Discussions R/W, Issues R/W, Profile R/W).`,
+              `3. Copy the new token, then:`,
+              `   \`\`\`sh`,
+              `   gh secret set GH_USER_PAT --repo ${owner}/${repo} --body <paste>`,
+              `   \`\`\``,
+              `4. Verify by dispatching: Actions -> Maintain user-scope features -> Run workflow.`,
+              `5. Close this issue.`,
+              ``,
+              `_Posted by \`.github/workflows/secret-expiry-check.yml\` (job: \`check-gh-user-pat\`)._`,
+            ].join('\n');
+            if (already) {
+              await github.rest.issues.update({
+                owner, repo, issue_number: already.number,
+                title, body,
+              });
+              core.info(`Updated existing PAT-rotation issue #${already.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo, title, body,
+                labels: ['security', 'release-blocker'],
+              });
+              core.info(`Opened PAT-rotation issue #${created.data.number}`);
+            }

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -32,9 +32,23 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    # Bot PRs (Dependabot / Renovate / github-actions) don't get a welcome.
-    # The check below handles human PRs + issues separately.
-    if: github.event_name == 'issues' || github.event.pull_request.user.type != 'Bot'
+    # Skip for bots (Dependabot / Renovate / github-actions) AND for the
+    # maintainer + project members. The inline gh-count check below is
+    # defense-in-depth, but the author_association gate is cleaner --
+    # heron's young-repo edge case (kaelys-js had only 1 issue in this
+    # repo, so the count-based check posted a welcome on issue #82) is
+    # only avoidable by trusting GitHub's relationship metadata directly.
+    # OWNER / MEMBER / COLLABORATOR all skip; first-time contributors
+    # (NONE / FIRST_TIMER / FIRST_TIME_CONTRIBUTOR / CONTRIBUTOR) get
+    # the welcome.
+    if: |
+      (github.event_name == 'issues' || github.event.pull_request.user.type != 'Bot') &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'MEMBER' &&
+      github.event.issue.author_association != 'COLLABORATOR'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -33,16 +33,25 @@ jobs:
       issues: write
       pull-requests: write
     # Skip for bots (Dependabot / Renovate / github-actions) AND for the
-    # maintainer + project members. The inline gh-count check below is
-    # defense-in-depth, but the author_association gate is cleaner --
-    # heron's young-repo edge case (kaelys-js had only 1 issue in this
-    # repo, so the count-based check posted a welcome on issue #82) is
-    # only avoidable by trusting GitHub's relationship metadata directly.
-    # OWNER / MEMBER / COLLABORATOR all skip; first-time contributors
-    # (NONE / FIRST_TIMER / FIRST_TIME_CONTRIBUTOR / CONTRIBUTOR) get
-    # the welcome.
+    # maintainer + project members. Two-layer gate:
+    #   (a) per-event bot-check -- splits issues vs PR paths so the
+    #       issue.user.type is actually checked on `issues` events
+    #       (the previous `event_name == 'issues' || pr.user.type !=
+    #       Bot` short-circuited to true for ALL issue events,
+    #       letting bot-authored issues through)
+    #   (b) author_association OWNER/MEMBER/COLLABORATOR skip --
+    #       heron's young-repo edge case (kaelys-js had only 1
+    #       kaelys-js-authored issue in this repo when issue #82 was
+    #       auto-created, so the inline count-based check posted a
+    #       welcome on it) is only avoidable by trusting GitHub's
+    #       relationship metadata directly.
+    # First-time contributors (NONE / FIRST_TIMER / FIRST_TIME_CONTRIBUTOR
+    # / CONTRIBUTOR) get the welcome.
     if: |
-      (github.event_name == 'issues' || github.event.pull_request.user.type != 'Bot') &&
+      (
+        (github.event_name == 'issues' && github.event.issue.user.type != 'Bot') ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.user.type != 'Bot')
+      ) &&
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'COLLABORATOR' &&

--- a/scripts/system/apply-github-config.mjs
+++ b/scripts/system/apply-github-config.mjs
@@ -244,6 +244,64 @@ async function main() {
     }
   }
 
+  // ── 4b. Full settings audit (read-only checks for fields the script
+  //         can read but won't apply silently) ─────────────────────
+  // Surfaces visible-via-API state that doesn't fit the apply path
+  // above: visibility, has_wiki, has_projects, has_pages, has_downloads,
+  // default_branch, archived, image_url (social preview), license,
+  // and merge-policy toggles (allow_squash_merge / allow_merge_commit /
+  // allow_rebase_merge / allow_update_branch). Each is reported as a
+  // (notice) when the live value differs from the expected default --
+  // not as drift, because some of these are subjective preferences
+  // and forcing them via PATCH would be too aggressive. The notice
+  // gives the maintainer the actionable signal to fix in UI.
+  const EXPECTED_SETTINGS = {
+    has_wiki: false,
+    has_projects: true,
+    has_pages: true,
+    has_downloads: true,
+    default_branch: 'main',
+    archived: false,
+    disabled: false,
+    allow_squash_merge: true,
+    allow_merge_commit: false,
+    allow_rebase_merge: false,
+    allow_update_branch: true,
+    visibility: 'public',
+  };
+  const auditDiff = [];
+  for (const [k, expected] of Object.entries(EXPECTED_SETTINGS)) {
+    if (repoState[k] === undefined) continue; // field not visible to token
+    if (repoState[k] !== expected) {
+      auditDiff.push({ key: k, before: repoState[k], after: expected });
+    }
+  }
+  if (repoState.image_url === null || repoState.image_url === undefined) {
+    auditDiff.push({
+      key: 'image_url',
+      before: '(default auto-generated)',
+      after: '(custom upload via UI)',
+    });
+  }
+  if (!repoState.license || repoState.license.spdx_id === 'NOASSERTION') {
+    auditDiff.push({
+      key: 'license',
+      before: repoState.license?.spdx_id || 'NOASSERTION',
+      after: 'MIT (or any SPDX)',
+    });
+  }
+  if (auditDiff.length > 0) {
+    console.log('▸ Settings audit (read-only — see notices)');
+    for (const d of auditDiff) {
+      console.log(
+        `  (notice) ${d.key}: ${JSON.stringify(d.before)} (expected ${JSON.stringify(d.after)})`,
+      );
+    }
+    // Don't increment driftCount -- these are notices, not auto-applied.
+  } else {
+    console.log('▸ Settings audit: ok');
+  }
+
   // ── 5. Branch protection rulesets ──────────────────────────────
   const liveRulesets = gh('GET', `/repos/${repoSlug}/rulesets`) || [];
   const desiredRulesets = readRulesets();

--- a/scripts/system/apply-github-features.mjs
+++ b/scripts/system/apply-github-features.mjs
@@ -189,7 +189,46 @@ if (liveSec.secret_scanning_validity_checks?.status !== 'enabled') {
   console.log('  secret_scanning_validity_checks: ok');
 }
 
-// ── 4. Summary ────────────────────────────────────────────────
+// ── 4. GitHub Pages enable (source = "workflow") ────────────────
+// pages.yml deploys docs/ via the `actions/deploy-pages` action. That
+// step requires Pages to be enabled on the repo with `build_type =
+// workflow`. The setting is admin-scope: PUT /repos/{r}/pages creates
+// or updates the Pages config. When the requesting token lacks the
+// admin scope (GITHUB_TOKEN does, GH_USER_PAT may not), the call
+// returns 403 -- log + continue so the workflow stays green; the
+// maintainer can flip Settings → Pages → "GitHub Actions" by hand.
+console.log('▸ GitHub Pages');
+const pagesLive = gh('GET', `/repos/${REPO}/pages`);
+if (pagesLive?.__error?.includes('Not Found')) {
+  console.log('  pages: missing -> creating with build_type=workflow');
+  driftCount++;
+  if (!VERIFY_ONLY) {
+    const create = gh('POST', `/repos/${REPO}/pages`, { build_type: 'workflow' });
+    if (create?.__error) {
+      if (/Resource not accessible/i.test(create.__error)) {
+        console.log(
+          '  (skip) pages: PAT lacks admin scope -- flip Settings -> Pages -> Source = "GitHub Actions" manually.',
+        );
+      } else {
+        console.log(`  pages: create failed -- ${create.__error.split('\n')[0]}`);
+      }
+    } else {
+      console.log('  pages: created');
+    }
+  }
+} else if (pagesLive?.build_type !== 'workflow') {
+  logChange('pages.build_type', pagesLive?.build_type || 'unset', 'workflow');
+  if (!VERIFY_ONLY) {
+    const update = gh('PUT', `/repos/${REPO}/pages`, { build_type: 'workflow' });
+    if (update?.__error && !/Resource not accessible/i.test(update.__error)) {
+      console.log(`  pages: update failed -- ${update.__error.split('\n')[0]}`);
+    }
+  }
+} else {
+  console.log('  pages.build_type: ok (workflow)');
+}
+
+// ── 5. Summary ────────────────────────────────────────────────
 console.log('');
 if (driftCount === 0) {
   console.log('✓ No drift -- features state matches SSOT.');

--- a/scripts/system/apply-user-features.mjs
+++ b/scripts/system/apply-user-features.mjs
@@ -113,13 +113,18 @@ if (roadmapIssue?.node_id && !VERIFY_ONLY) {
 }
 
 // ── 2. Pinned discussions ("Introduce yourself" + "Start here") ──
+// Pinning state is exposed via repository.pinnedDiscussions (a separate
+// connection); the `Discussion` type itself does NOT have an `isPinned`
+// field. Query both: existing discussions by title (for create-or-skip
+// decision) + pinnedDiscussions (to detect already-pinned ones).
 console.log('▸ Pinned discussions');
 const discussionsQ = ghGraphQL(
   `query($o: String!, $n: String!) {
     repository(owner: $o, name: $n) {
       id
       discussionCategories(first: 30) { nodes { id name } }
-      discussions(first: 50) { nodes { id title isPinned } }
+      discussions(first: 50) { nodes { id title } }
+      pinnedDiscussions(first: 10) { nodes { discussion { id title } } }
     }
   }`,
   { o: REPO.split('/')[0], n: REPO.split('/')[1] },
@@ -134,6 +139,9 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
   const repoId = discussionsQ.data.repository.id;
   const cats = discussionsQ.data.repository.discussionCategories.nodes;
   const generalCat = cats.find((c) => /^(General|Q&A|Welcome)$/i.test(c.name)) || cats[0] || null;
+  const pinnedIds = new Set(
+    (discussionsQ.data.repository.pinnedDiscussions?.nodes || []).map((n) => n.discussion.id),
+  );
   const WANTED = [
     {
       title: 'Introduce yourself',
@@ -149,7 +157,7 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
       (d) => d.title === w.title,
     );
     if (existing) {
-      if (!existing.isPinned) {
+      if (!pinnedIds.has(existing.id)) {
         if (VERIFY_ONLY) {
           drift(`"${w.title}" discussion`, 'unpinned');
         } else {
@@ -178,8 +186,9 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
           }`,
           { r: repoId, c: generalCat.id, t: w.title, b: w.body },
         );
-        if (create?.__error) {
-          console.log(`  "${w.title}": create failed -- ${create.__error.split('\n')[0]}`);
+        if (create?.__error || create?.errors) {
+          const e = create?.__error?.split('\n')[0] || create?.errors?.[0]?.message;
+          console.log(`  "${w.title}": create failed -- ${e}`);
         } else {
           const newId = create.data.createDiscussion.discussion.id;
           const pin = ghGraphQL(
@@ -219,8 +228,16 @@ if (projectsQ?.__error || !projectsQ?.data?.user) {
       `mutation($o: ID!, $t: String!) { createProjectV2(input: {ownerId: $o, title: $t}) { projectV2 { id title } } }`,
       { o: projectsQ.data.user.id, t: 'Heron Roadmap' },
     );
-    if (create?.__error) {
-      console.log(`  Heron Roadmap: create failed -- ${create.__error.split('\n')[0]}`);
+    if (create?.__error || create?.errors) {
+      const e = create?.__error?.split('\n')[0] || create?.errors?.[0]?.message;
+      if (/Resource not accessible/i.test(e)) {
+        console.log(
+          `  (skip) Heron Roadmap project: PAT lacks 'projects: write' scope -- update at ` +
+            `https://github.com/settings/personal-access-tokens and re-run.`,
+        );
+      } else {
+        console.log(`  Heron Roadmap: create failed -- ${e}`);
+      }
     } else {
       console.log(`  Heron Roadmap: created`);
       driftCount++;
@@ -228,80 +245,51 @@ if (projectsQ?.__error || !projectsQ?.data?.user) {
   }
 }
 
-// ── 4. 5 standard saved replies ─────────────────────────────────
-console.log('▸ Saved replies');
-const SAVED_REPLIES = [
-  {
-    title: 'Thanks for the PR',
-    body: "Thanks for the contribution! CI is running -- I'll review once it's green.",
-  },
-  {
-    title: 'Please add a test',
-    body: 'Could you add a regression test for this? See `docs/TESTING.md` for the convention.',
-  },
-  {
-    title: 'Reproduction needed',
-    body: 'Could you share the exact command + a small repro? I want the fix to target the right behaviour.',
-  },
-  {
-    title: 'Help wanted',
-    body: "This looks like a good `help wanted` candidate. If you'd like to take it, please comment + I'll assign.",
-  },
-  {
-    title: 'Closing as duplicate',
-    body: 'Closing as a duplicate of #N. Continuing the conversation there.',
-  },
-];
-const repliesQ = ghGraphQL(`query { viewer { savedReplies(first: 100) { nodes { id title } } } }`);
-if (repliesQ?.__error || !repliesQ?.data?.viewer) {
-  console.log(
-    `  (skip) couldn't query saved replies -- ${repliesQ?.__error?.split('\n')[0] || 'no viewer'}`,
-  );
-} else {
-  const have = new Set((repliesQ.data.viewer.savedReplies.nodes || []).map((n) => n.title));
-  for (const r of SAVED_REPLIES) {
-    if (have.has(r.title)) {
-      console.log(`  "${r.title}": ok`);
-    } else if (VERIFY_ONLY) {
-      drift(`"${r.title}" saved reply`, 'missing');
-    } else {
-      const create = ghGraphQL(
-        `mutation($t: String!, $b: String!) { createSavedReply(input: {title: $t, body: $b}) { savedReply { id title } } }`,
-        { t: r.title, b: r.body },
-      );
-      if (create?.__error) {
-        console.log(`  "${r.title}": create failed -- ${create.__error.split('\n')[0]}`);
-      } else {
-        console.log(`  "${r.title}": created`);
-        driftCount++;
-      }
-    }
-  }
-}
+// ── 4. Saved replies ─ NO-OP (no public GraphQL/REST API) ───────
+// GitHub does not expose saved-reply mutations on the public GraphQL
+// schema (only available on enterprise installs, and the field name
+// drifts between previews). They're user-scoped UI-only objects --
+// the maintainer creates them once at https://github.com/settings/replies
+// and the reconciler can't help. Skipping this section keeps
+// `maintain-user-features.yml` reliably green; remove this comment
+// + add an entry to TODO-INSTRUCTIONS.md if the API ever lands.
+console.log(
+  '▸ Saved replies: SKIPPED (no public API -- create via UI at github.com/settings/replies)',
+);
 
 // ── 5. Profile README at <owner>/<owner> ────────────────────────
 console.log(`▸ Profile README at ${OWNER}/${OWNER}`);
 const README = `# ${OWNER}\n\n> Builder. Shipping [Heron](https://github.com/${OWNER}/heron) and a handful of smaller tools.\n\n## What I'm working on\n\n- **[Heron](https://github.com/${OWNER}/heron)** -- AI-agnostic job-search automation.\n\n## Reach me\n\n- GitHub: [@${OWNER}](https://github.com/${OWNER})\n- Sponsor: [github.com/sponsors/${OWNER}](https://github.com/sponsors/${OWNER})\n- Discord: <https://discord.gg/8pRpHETxa4> (Heron community)\n\n<sub>This README auto-applies from \`.github/workflows/maintain-user-features.yml\` in the Heron repo. Edits made directly to this file are overwritten on the next reconcile.</sub>\n`;
-const profileExists = gh('GET', `/repos/${OWNER}/${OWNER}`);
-if (profileExists?.__error?.includes('Not Found')) {
-  if (VERIFY_ONLY) {
-    drift(`profile repo ${OWNER}/${OWNER}`, 'missing');
-  } else {
-    // Create via REST.
-    const created = gh('POST', `/user/repos`, {
-      name: OWNER,
-      description: `${OWNER}'s profile -- pinned + sponsor link + Heron`,
-      private: false,
-      auto_init: true,
-    });
-    if (created?.__error) {
-      console.log(`  Profile repo: create failed -- ${created.__error.split('\n')[0]}`);
+
+// Always TRY to create the profile repo. POST /user/repos is idempotent
+// when the repo already exists -- GitHub returns 422 "name already
+// exists" which we treat as a no-op. Avoids the previous GET-then-decide
+// flow that races against propagation + relies on a __error.includes
+// substring match that's fragile across gh CLI versions.
+if (!VERIFY_ONLY) {
+  const repoCreate = gh('POST', `/user/repos`, {
+    name: OWNER,
+    description: `${OWNER}'s profile`,
+    private: false,
+    auto_init: true,
+  });
+  if (repoCreate?.__error) {
+    if (/name already exists|already exists on this account/i.test(repoCreate.__error)) {
+      // expected when the repo already exists -- continue to README upsert
+    } else if (/Resource not accessible/i.test(repoCreate.__error)) {
+      console.log(
+        `  (skip) Profile repo: PAT lacks 'public_repo' or 'repo' scope on user-account level -- ` +
+          `cannot create ${OWNER}/${OWNER}. Create manually + re-run.`,
+      );
     } else {
-      console.log(`  Profile repo: created`);
-      driftCount++;
+      console.log(`  Profile repo: ${repoCreate.__error.split('\n')[0]}`);
     }
+  } else {
+    console.log(`  Profile repo: created`);
+    driftCount++;
   }
 }
+
 // Upsert README via contents API. Idempotent on identical content.
 const liveMeta = gh('GET', `/repos/${OWNER}/${OWNER}/contents/README.md`);
 if (liveMeta?.content) {

--- a/scripts/system/apply-user-features.mjs
+++ b/scripts/system/apply-user-features.mjs
@@ -139,8 +139,14 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
   const repoId = discussionsQ.data.repository.id;
   const cats = discussionsQ.data.repository.discussionCategories.nodes;
   const generalCat = cats.find((c) => /^(General|Q&A|Welcome)$/i.test(c.name)) || cats[0] || null;
+  // Pinned discussions can carry a null `discussion` node when the
+  // underlying discussion was deleted but the pin record lingered, or
+  // when the PAT scope hides it. Filter before .map so we don't crash
+  // on the .id deref.
   const pinnedIds = new Set(
-    (discussionsQ.data.repository.pinnedDiscussions?.nodes || []).map((n) => n.discussion.id),
+    (discussionsQ.data.repository.pinnedDiscussions?.nodes || [])
+      .filter((n) => n?.discussion)
+      .map((n) => n.discussion.id),
   );
   const WANTED = [
     {
@@ -327,6 +333,30 @@ if (liveMeta?.content) {
       driftCount++;
     }
   }
+}
+
+// ── 6. GitHub Sponsors listing audit (read-only) ────────────────
+// We can't enable Sponsors via API -- the maintainer has to complete
+// bank/tax verification on github.com/sponsors/<OWNER>. But we CAN
+// warn when the listing is still pending so the `funding` field in
+// package.json + `.github/FUNDING.yml` aren't dead links.
+console.log('▸ GitHub Sponsors listing');
+const sponsorsQ = ghGraphQL(`query($l: String!) { user(login: $l) { hasSponsorsListing } }`, {
+  l: OWNER,
+});
+if (sponsorsQ?.__error || sponsorsQ?.errors || !sponsorsQ?.data?.user) {
+  const reason =
+    sponsorsQ?.__error?.split('\n')[0] || sponsorsQ?.errors?.[0]?.message || 'no user data';
+  console.log(`  (skip) couldn't query Sponsors listing -- ${reason}`);
+} else if (sponsorsQ.data.user.hasSponsorsListing) {
+  console.log('  Sponsors listing: ok');
+} else {
+  console.log(
+    `  Sponsors listing: NOT YET VERIFIED -- complete signup at ` +
+      `https://github.com/sponsors/${OWNER} (bank + tax required; no API path).`,
+  );
+  // Not flagged as drift -- it's a one-time manual step, not state
+  // the script can reconcile. Surfaced as a notice only.
 }
 
 // ── Summary ─────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `6163bf2` (run [#257](https://github.com/kaelys-js/heron/actions/runs/26257029021))
<!-- CI-STATUS-MARKER-END -->



## Summary

Hotfix for issues surfaced by κ's first push:main run on commit 9f74825 (the κ merge itself). The 3 new workflows fired cleanly with status SUCCESS, but the **inner script logs revealed 4 silent-failure paths** that the script swallowed as warnings (so the outer workflow stayed green). One pre-existing issue (Pages failing since θ) is also folded in.

## Motivation

Watching maintain-user-features on commit 9f74825 surface its actual reconciliation output exposed that I was shipping a script with 3 mis-shaped GraphQL queries + 1 fragile control-flow path. Specifically: `Discussion.isPinned` is not a field (the correct path is `repository.pinnedDiscussions`); `createSavedReply` is not on the public GraphQL Mutation type; and the profile-README flow's GET-then-decide pattern raced against repo propagation. Independently, Pages has been failing on every push:main since θ because the workflow assumes Pages source is set to "GitHub Actions" but nothing reconciles that. Bundling fixes for clarity.

## What's fixed

1. **`apply-user-features.mjs` § 2 (pinned discussions):** restructured query to fetch `repository.pinnedDiscussions(first: 10) { nodes { discussion { id title } } }` and check the pinned-set via `pinnedIds.has(existing.id)` — removed the invalid `Discussion.isPinned` field.
2. **`apply-user-features.mjs` § 4 (saved replies):** deleted the create-saved-reply path. `createSavedReply` is NOT on the public GraphQL Mutation schema (verified via `__type` introspection). Section is now a one-line marker.
3. **`apply-user-features.mjs` § 5 (profile README):** rewrote the create-or-noop flow to always POST `/user/repos` with `auto_init: true` and absorb the "name already exists" 422 as a no-op. Removes the racy GET-then-decide pattern + the fragile substring match on the error message.
4. **`apply-github-features.mjs` § 4 (NEW — GitHub Pages):** add a `POST /repos/{r}/pages` with `build_type=workflow` path. Reconciles the source toggle that `pages.yml` requires. Falls back to a clear "(skip) PAT lacks admin scope" notice when the calling token can't make admin changes.
5. **PAT-scope UX (both scripts):** when GitHub returns "Resource not accessible by personal access token", the script now prints a concrete pointer to `https://github.com/settings/personal-access-tokens` instead of a generic error string.

## Test plan

- [x] `node --check` on both modified scripts
- [x] Pre-push gates locally green: actionlint, format-check, vitest (full 60s matrix), typecheck, swiftlint-strict, ktlint-strict, no-slop, comment-style, english-only
- [ ] CI: all 16 required checks pass on PR
- [ ] Post-merge: `maintain-user-features.yml` runs on push:main, log shows "Roadmap 2026 pin: ok" (already pinned from κ), pinned discussions either ok or "Resource not accessible" if PAT scope still missing, "Saved replies: SKIPPED" notice, profile-repo + README either created or "name already exists" no-op
- [ ] Post-merge: `maintain-features.yml` log shows new "▸ GitHub Pages" section with either "pages: created" (if PAT scope) or "(skip) PAT lacks admin scope" notice
- [ ] Subsequent push:main: `pages.yml` deploys successfully (after Pages is enabled either by the workflow or manually via Settings → Pages → "GitHub Actions")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Pages enablement with best-effort behavior and clearer access-scope skip messages.
  * Better handling for pinned discussions, profile README creation, and project creation with clearer skip/error messaging.
  * Added read-only audits for GitHub Sponsors listing and repository settings that report informational mismatches.

* **New Features**
  * Workflow updates: preparatory toolchain step, social-preview image regeneration and artifact upload.
  * Periodic PAT expiry check that can open/update an issue when rotation is needed.

* **Bug Fixes**
  * Welcome workflow now skips welcome comments for owners, members, and collaborators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->