### PR TITLE
fix(ci): reorder reconcile-before-PNG + drop pinDiscussion mutation

### DIFF
--- a/.github/workflows/maintain-features.yml
+++ b/.github/workflows/maintain-features.yml
@@ -83,26 +83,11 @@ jobs:
         with:
           install_deps: "true"
 
-      - name: Regenerate social preview PNG
-        # Keeps ui/static/og/default.png fresh so the maintainer can
-        # upload it via Settings -> General -> Social preview at any
-        # time and pick up the latest brand. GitHub has no public API
-        # to push the social preview image; this is the cleanest
-        # automation possible until that API ships.
-        run: pnpm og:generate
-
-      - name: Upload social preview PNG as artifact
-        # Persists ui/static/og/default.png from the ephemeral runner
-        # so the maintainer can download it from the Actions run page
-        # + drag into Settings -> Social preview. 90-day retention is
-        # the GitHub default; enough lead time across rebrands.
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: social-preview-png
-          path: ui/static/og/default.png
-          if-no-files-found: error
-          retention-days: 90
-
+      # IMPORTANT ordering: reconcile runs BEFORE og:generate so the
+      # Pages enable + environment/label/validity-check reconciliation
+      # ships even if PNG generation fails (chromium install issues,
+      # disk full, etc.). The PNG regen is a "nice to have" that
+      # should never gate the actual reconcile work.
       - name: Reconcile
         env:
           GH_TOKEN: ${{ secrets.GH_USER_PAT || secrets.GITHUB_TOKEN }}
@@ -114,3 +99,36 @@ jobs:
           else
             node scripts/system/apply-github-features.mjs
           fi
+
+      - name: Install Playwright chromium for OG generation
+        # generate-og-cards.mjs uses Playwright + chromium to render
+        # the social-card HTML. Default ubuntu runner doesn't bundle
+        # the chromium binary; --with-deps adds the system libs too.
+        # Failure here is non-fatal (continue-on-error) -- the
+        # reconcile already shipped above; missing PNG just means the
+        # artifact upload step (also continue-on-error) is skipped.
+        run: pnpm --filter ui exec playwright install --with-deps chromium
+        continue-on-error: true
+
+      - name: Regenerate social preview PNG
+        # Keeps ui/static/og/default.png fresh so the maintainer can
+        # upload it via Settings -> General -> Social preview at any
+        # time and pick up the latest brand. GitHub has no public API
+        # to push the social preview image; this is the cleanest
+        # automation possible until that API ships.
+        # continue-on-error because the reconcile already happened
+        # and the artifact upload below also handles missing files.
+        run: pnpm og:generate
+        continue-on-error: true
+
+      - name: Upload social preview PNG as artifact
+        # Persists ui/static/og/default.png from the ephemeral runner
+        # so the maintainer can download it from the Actions run page
+        # + drag into Settings -> Social preview. Skips silently if
+        # the PNG didn't generate (e.g. chromium install failed).
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: social-preview-png
+          path: ui/static/og/default.png
+          if-no-files-found: ignore
+          retention-days: 90

--- a/scripts/system/apply-user-features.mjs
+++ b/scripts/system/apply-user-features.mjs
@@ -112,12 +112,15 @@ if (roadmapIssue?.node_id && !VERIFY_ONLY) {
   }
 }
 
-// ── 2. Pinned discussions ("Introduce yourself" + "Start here") ──
-// Pinning state is exposed via repository.pinnedDiscussions (a separate
-// connection); the `Discussion` type itself does NOT have an `isPinned`
-// field. Query both: existing discussions by title (for create-or-skip
-// decision) + pinnedDiscussions (to detect already-pinned ones).
-console.log('▸ Pinned discussions');
+// ── 2. Discussions ("Introduce yourself" + "Start here") ──
+// CREATE the discussions when missing. We CANNOT pin them programmatically
+// -- `pinDiscussion` is NOT on the public GraphQL Mutation schema (only
+// `pinIssue`, `pinIssueComment`, `pinEnvironment` exist). Pinning is a
+// UI-only feature; surface the URL for the one-time manual step.
+//
+// The `pinnedDiscussions` query is kept (read-only) so we can log
+// whether each WANTED discussion happens to already be pinned via UI.
+console.log('▸ Discussions');
 const discussionsQ = ghGraphQL(
   `query($o: String!, $n: String!) {
     repository(owner: $o, name: $n) {
@@ -158,28 +161,17 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
       body: 'Quickstart for new contributors. See `.github/CONTRIBUTING.md` for the canonical guide.',
     },
   ];
+  let needsUiPin = false;
   for (const w of WANTED) {
     const existing = discussionsQ.data.repository.discussions.nodes.find(
       (d) => d.title === w.title,
     );
     if (existing) {
-      if (!pinnedIds.has(existing.id)) {
-        if (VERIFY_ONLY) {
-          drift(`"${w.title}" discussion`, 'unpinned');
-        } else {
-          const pin = ghGraphQL(
-            `mutation($id: ID!) { pinDiscussion(input: {discussionId: $id}) { pinnedDiscussion { id } } }`,
-            { id: existing.id },
-          );
-          if (pin?.__error && !/maximum.*pinned|already/i.test(pin.__error)) {
-            console.log(`  "${w.title}" pin: ${pin.__error.split('\n')[0]}`);
-          } else {
-            console.log(`  "${w.title}" pin: ok`);
-          }
-        }
-      } else {
-        console.log(`  "${w.title}": ok`);
-      }
+      const isPinned = pinnedIds.has(existing.id);
+      console.log(
+        `  "${w.title}": exists${isPinned ? ' + pinned (UI)' : ' (UNPINNED -- pin via UI)'}`,
+      );
+      if (!isPinned) needsUiPin = true;
     } else if (generalCat) {
       if (VERIFY_ONLY) {
         drift(`"${w.title}" discussion`, 'missing');
@@ -196,20 +188,18 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
           const e = create?.__error?.split('\n')[0] || create?.errors?.[0]?.message;
           console.log(`  "${w.title}": create failed -- ${e}`);
         } else {
-          const newId = create.data.createDiscussion.discussion.id;
-          const pin = ghGraphQL(
-            `mutation($id: ID!) { pinDiscussion(input: {discussionId: $id}) { pinnedDiscussion { id } } }`,
-            { id: newId },
-          );
-          if (pin?.__error && !/maximum.*pinned|already/i.test(pin.__error)) {
-            console.log(`  "${w.title}": created but pin failed -- ${pin.__error.split('\n')[0]}`);
-          } else {
-            console.log(`  "${w.title}": created + pinned`);
-          }
+          console.log(`  "${w.title}": created (UNPINNED -- pin via UI)`);
+          needsUiPin = true;
           driftCount++;
         }
       }
     }
+  }
+  if (needsUiPin && !VERIFY_ONLY) {
+    console.log(
+      `  (manual step) Pin both discussions via UI at https://github.com/${REPO}/discussions ` +
+        `-- pinDiscussion is not on the public GraphQL Mutation schema.`,
+    );
   }
 }
 

--- a/scripts/system/apply-user-features.mjs
+++ b/scripts/system/apply-user-features.mjs
@@ -171,7 +171,14 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
       console.log(
         `  "${w.title}": exists${isPinned ? ' + pinned (UI)' : ' (UNPINNED -- pin via UI)'}`,
       );
-      if (!isPinned) needsUiPin = true;
+      if (!isPinned) {
+        needsUiPin = true;
+        // Treat unpinned existing discussions as drift so --check exits
+        // non-zero + apply runs increment the change counter. Pinning
+        // is UI-only, but the OUTCOME (a discussion not in pinned state)
+        // is real drift; bookkeep it the same way.
+        drift(`"${w.title}" discussion`, 'unpinned (manual UI pin required)');
+      }
     } else if (generalCat) {
       if (VERIFY_ONLY) {
         drift(`"${w.title}" discussion`, 'missing');
@@ -190,7 +197,8 @@ if (discussionsQ?.__error || discussionsQ?.errors || !discussionsQ?.data?.reposi
         } else {
           console.log(`  "${w.title}": created (UNPINNED -- pin via UI)`);
           needsUiPin = true;
-          driftCount++;
+          driftCount++; // for the create
+          drift(`"${w.title}" discussion`, 'unpinned (manual UI pin required)');
         }
       }
     }
@@ -227,11 +235,13 @@ if (projectsQ?.__error || !projectsQ?.data?.user) {
     if (create?.__error || create?.errors) {
       const e = create?.__error?.split('\n')[0] || create?.errors?.[0]?.message;
       if (/Resource not accessible/i.test(e)) {
+        const tokenLabel = process.env.GH_USER_PAT ? 'GH_USER_PAT' : 'GH_TOKEN';
         console.log(
-          `  (skip) Heron Roadmap project: fine-grained PATs don't expose user-scope ` +
-            `Project v2 creation. EASIEST FIX: create it ONCE via UI at ` +
-            `https://github.com/users/${OWNER}/projects (click "New project" -> Roadmap template ` +
-            `-> name "Heron Roadmap"). Subsequent runs will detect + skip.`,
+          `  (skip) Heron Roadmap project: ${tokenLabel} can't create user-scope Project v2s. ` +
+            `If running under GH_TOKEN: set GH_USER_PAT (a PAT with project scope) and re-run. ` +
+            `Otherwise: create it ONCE via UI at https://github.com/users/${OWNER}/projects ` +
+            `(click "New project" -> Roadmap template -> name "Heron Roadmap"). ` +
+            `Subsequent runs will detect + skip.`,
         );
       } else {
         console.log(`  Heron Roadmap: create failed -- ${e}`);
@@ -275,12 +285,13 @@ if (!VERIFY_ONLY) {
     if (/name already exists|already exists on this account/i.test(repoCreate.__error)) {
       // expected when the repo already exists -- continue to README upsert
     } else if (/Resource not accessible/i.test(repoCreate.__error)) {
+      const tokenLabel = process.env.GH_USER_PAT ? 'GH_USER_PAT' : 'GH_TOKEN';
       console.log(
-        `  (skip) Profile repo: fine-grained PATs don't grant user-account repo CREATION. ` +
-          `EASIEST FIX: create it ONCE via UI -- https://github.com/new -> name "${OWNER}", ` +
-          `public, with README -- THEN edit the PAT at https://github.com/settings/personal-access-tokens, ` +
-          `"Only select repositories" -> add "${OWNER}/${OWNER}" with Contents Read+Write. ` +
-          `Subsequent runs will upsert the README idempotently.`,
+        `  (skip) Profile repo: ${tokenLabel} can't create user-account repos. ` +
+          `If running under GH_TOKEN: set GH_USER_PAT (a PAT with repo scope at account level) ` +
+          `and re-run. Otherwise: create it ONCE via UI -- https://github.com/new -> name "${OWNER}", ` +
+          `public, with README -- THEN add "${OWNER}/${OWNER}" to the PAT's "Only select repositories" ` +
+          `list with Contents Read+Write. Subsequent runs will upsert the README idempotently.`,
       );
     } else {
       console.log(`  Profile repo: ${repoCreate.__error.split('\n')[0]}`);

--- a/scripts/system/apply-user-features.mjs
+++ b/scripts/system/apply-user-features.mjs
@@ -228,8 +228,10 @@ if (projectsQ?.__error || !projectsQ?.data?.user) {
       const e = create?.__error?.split('\n')[0] || create?.errors?.[0]?.message;
       if (/Resource not accessible/i.test(e)) {
         console.log(
-          `  (skip) Heron Roadmap project: PAT lacks 'projects: write' scope -- update at ` +
-            `https://github.com/settings/personal-access-tokens and re-run.`,
+          `  (skip) Heron Roadmap project: fine-grained PATs don't expose user-scope ` +
+            `Project v2 creation. EASIEST FIX: create it ONCE via UI at ` +
+            `https://github.com/users/${OWNER}/projects (click "New project" -> Roadmap template ` +
+            `-> name "Heron Roadmap"). Subsequent runs will detect + skip.`,
         );
       } else {
         console.log(`  Heron Roadmap: create failed -- ${e}`);
@@ -274,8 +276,11 @@ if (!VERIFY_ONLY) {
       // expected when the repo already exists -- continue to README upsert
     } else if (/Resource not accessible/i.test(repoCreate.__error)) {
       console.log(
-        `  (skip) Profile repo: PAT lacks 'public_repo' or 'repo' scope on user-account level -- ` +
-          `cannot create ${OWNER}/${OWNER}. Create manually + re-run.`,
+        `  (skip) Profile repo: fine-grained PATs don't grant user-account repo CREATION. ` +
+          `EASIEST FIX: create it ONCE via UI -- https://github.com/new -> name "${OWNER}", ` +
+          `public, with README -- THEN edit the PAT at https://github.com/settings/personal-access-tokens, ` +
+          `"Only select repositories" -> add "${OWNER}/${OWNER}" with Contents Read+Write. ` +
+          `Subsequent runs will upsert the README idempotently.`,
       );
     } else {
       console.log(`  Profile repo: ${repoCreate.__error.split('\n')[0]}`);


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `6406891` (run [#261](https://github.com/kaelys-js/heron/actions/runs/26257880184))
<!-- CI-STATUS-MARKER-END -->


## Summary

Hotfix for issues surfaced by the κ+1 first-run on push:main + the manual dispatch. The κ+1 reconcile-time logic was correct; the orchestration order + an over-optimistic GraphQL mutation guess were not.

## Motivation

After κ+1 merged + the workflows fired on commit 4c00219, two latent issues surfaced:

1. **`maintain-features.yml` FAILED on `pnpm og:generate`** — chromium isn't bundled in the ubuntu runner; Playwright fails with `Executable doesn't exist at chrome-headless-shell-linux64`. Worse, the PNG step ran BEFORE the reconcile step, so `set -e` aborted the job and the Pages enable (PUT /repos/{r}/pages) never ran. Pages stayed disabled. The auto-regenerate-PNG-on-push:main feature was gating the reconcile work that mattered.

2. **`pinDiscussion` GraphQL mutation does NOT exist on the public schema** (verified via `__type` introspection: only `pinIssue`, `pinIssueComment`, `pinEnvironment` are pin-related mutations). `maintain-user-features.yml` succeeded but the inner script logged "created but pin failed -- gh: Field 'pinDiscussion' doesn't exist on type 'Mutation'" twice. Worse, every weekly cron would re-attempt the failing mutation (the discussions exist but `pinnedIds.has(existing.id)` is false because the pin always fails).

## What's fixed

### `maintain-features.yml` reorder + tolerant PNG path

| Step | Before | After |
|---|---|---|
| 1 | `pnpm og:generate` | **Reconcile** (Pages enable, envs, labels, validity-checks) |
| 2 | `actions/upload-artifact` (if-no-files: error) | `playwright install --with-deps chromium` (continue-on-error) |
| 3 | **Reconcile** | `pnpm og:generate` (continue-on-error) |
| 4 | — | `actions/upload-artifact` (if-no-files: **ignore**) |

Reconcile work always ships; PNG regen is best-effort.

### `apply-user-features.mjs` section 2: drop `pinDiscussion`

Replaced the create-then-pin flow with create-then-log:
- Existing discussions → log pin-status from the read-only `pinnedDiscussions` query
- Missing discussions → CREATE then log "UNPINNED — pin via UI"
- When any remain unpinned → single trailing `(manual step) Pin both discussions via UI at https://github.com/<r>/discussions` notice

## Test plan

- [x] `node --check` on both modified files
- [x] `actionlint`, `verify-no-slop`, `verify-comment-style`, `verify-english-only` all green locally
- [ ] CI: all 16 required checks pass
- [ ] Post-merge: `maintain-features.yml` runs on push:main, reconcile completes (Pages enable + envs + labels + validity-checks), then PNG regen attempts (may succeed or skip cleanly)
- [ ] Post-merge: `maintain-user-features.yml` runs, log shows "Roadmap 2026 pin: ok" + both discussions in "exists/created (UNPINNED — pin via UI)" state + trailing manual-step pointer
- [ ] Subsequent push:main: `pages.yml` deploys successfully now that Pages is enabled
- [ ] Once you UI-pin the 2 discussions, the next reconcile shows "exists + pinned (UI)" for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by running reconciliation before preview generation so environment/label/validity checks still occur even if preview creation fails; artifact uploads now silently skip missing previews instead of failing.
  * Updated automation for discussions/projects/repos to avoid programmatic pinning/creation when unsupported; scripts now record drift, flag required manual UI steps, and provide clear instructions for maintainers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->