### PR TITLE
chore: pin config schemas + static discord badge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 # CodeRabbit AI -- automated PR review configuration.
-# Schema: https://docs.coderabbit.ai/reference/yaml-template
+# Schema reference docs: https://docs.coderabbit.ai/reference/yaml-template
 #
 # CodeRabbit is a GitHub App that auto-reviews PRs. Install (once per
 # repo or org-wide) at:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://www.schemastore.org/swiftlint.json
+# yaml-language-server: $schema=https://json.schemastore.org/swiftlint.json
 # SwiftLint config -- applies to every Swift file in the repo.
 #
 # Discovery: swiftlint walks up from the directory it's invoked in and

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://www.schemastore.org/swiftlint.json
 # SwiftLint config -- applies to every Swift file in the repo.
 #
 # Discovery: swiftlint walks up from the directory it's invoked in and

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://www.schemastore.org/yamllint.json
+# yaml-language-server: $schema=https://json.schemastore.org/yamllint.json
 # yamllint config -- repo-wide.
 # We use yamllint as a syntax / structure gate, not a strict 80-col style
 # linter. Workflow YAMLs and lefthook.yml have inline shell commands +

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://www.schemastore.org/yamllint.json
 # yamllint config -- repo-wide.
 # We use yamllint as a syntax / structure gate, not a strict 80-col style
 # linter. Workflow YAMLs and lefthook.yml have inline shell commands +

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kaelys-js/heron/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kaelys-js/heron)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/github/v/release/kaelys-js/heron)](https://github.com/kaelys-js/heron/releases)
-[![Discord](https://img.shields.io/discord/1507162919421612134?label=discord&logo=discord)](https://discord.gg/MyFbztUK5U)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/MyFbztUK5U)
 [![REUSE compliant](https://img.shields.io/badge/REUSE-compliant-blue)](https://reuse.software)
 
 [**Quick start**](#quick-start) · [**Documentation**](docs/) · [**Architecture**](docs/ARCHITECTURE.md) · [**FAQ**](docs/FAQ.md) · [**Discord**](https://discord.gg/MyFbztUK5U) · [**Sponsor**](https://github.com/sponsors/kaelys-js)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://www.schemastore.org/codecov.json
+# yaml-language-server: $schema=https://json.schemastore.org/codecov.json
 # HP8 -- Codecov PR-comment + coverage gate shape.
 #
 # Lives at repo root (codecov.io scans this path). Shapes:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://www.schemastore.org/codecov.json
 # HP8 -- Codecov PR-comment + coverage gate shape.
 #
 # Lives at repo root (codecov.io scans this path). Shapes:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/lefthook.json
 # Lefthook -- git hooks manager.
 #
 # Run hooks in parallel, skip on rebase/merge, share config across the team.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+#:schema https://json.schemastore.org/pyproject.json
 # pyproject.toml — Python tooling config (ruff + future tools).
 #
 # Schema reference (per-tool — there's no canonical pyproject schema):


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `28e9b79` (run [#276](https://github.com/kaelys-js/heron/actions/runs/26263678735))
<!-- CI-STATUS-MARKER-END -->


## Summary

Three small audit-cleanup items the maintainer flagged:

1. **Pin `$schema` URLs on 6 repo-root config files** for editor autocomplete + validation.
2. **Switch the README Discord badge to static** — the dynamic widget badge was rendering as "disabled" because the Discord server widget toggle is off (and the toggle's location is hard to find in Discord's 2024-2025 redesigned UX).
3. **Out-of-band**: re-enabled `release.yml` via `gh workflow enable` — it was `disabled_manually` since May 8, blocking Release Please from generating CHANGELOG entries on every merge since v0.1.0.

## Schema directives added

| File | Schema URL | Format |
|---|---|---|
| `.yamllint.yml` | `https://www.schemastore.org/yamllint.json` | `# yaml-language-server: $schema=...` |
| `.swiftlint.yml` | `https://www.schemastore.org/swiftlint.json` | same |
| `.coderabbit.yaml` | `https://coderabbit.ai/integrations/schema.v2.json` | same (kept doc-link comment as fallback ref) |
| `codecov.yml` | `https://www.schemastore.org/codecov.json` | same |
| `lefthook.yml` | `https://json.schemastore.org/lefthook.json` | same |
| `pyproject.toml` | `https://json.schemastore.org/pyproject.json` | `#:schema ...` (Taplo TOML directive) |
| `REUSE.toml` | — | _no published schema; skipped_ |

The directives are pure editor hints — no runtime behaviour change.

## Release Please catch-up (expected after this PR merges)

`release.yml` is now active. Next `push:main` (i.e. this PR's merge) triggers Release Please. It will scan commits since `v0.1.0` (May 15) and open one fat release PR titled `chore(main): release v0.2.0` accumulating:

- θ #80 (fix: CI delete SETTINGS.md + Pages SHA-pin + dep-alerts)
- κ #81 (feat: convert reconciler scripts to workflows + add CR threads gate)
- κ+1 #84 (fix: apply-user-features 3-bug + Pages enable + PAT-scope UX)
- κ+2 #87 (fix: reorder reconcile-before-PNG + drop pinDiscussion)
- λ #88 (feat: screenshot auto-approve + roadmap + profile README polish)
- μ #89 (fix: gitsign revert + stats badges + AGENTS split + mascot SVGs)
- This PR ν (chore: schemas + static badge)
- Plus the dependabot bumps merged in between

Several `feat:` commits → minor bump → **v0.2.0**. Merge that release PR to cut v0.2.0 + trigger `native-release.yml` for DMG/exe/AppImage/TestFlight builds.

## Test plan

- [x] All 6 schema directives present + correct
- [x] `verify-no-slop`, `verify-comment-style`, `verify-english-only` green
- [x] `release.yml` state confirmed as `active` via `gh api`
- [ ] CI: all 16 required checks pass
- [ ] Post-merge: `release.yml` fires on the merge commit
- [ ] Post-merge: Release Please opens `chore(main): release v0.2.0` PR
- [ ] Manual: maintainer reviews + merges the release PR
- [ ] Cascade: `native-release.yml` builds + uploads to TestFlight + attaches DMG/exe/AppImage to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Discord community badge styling in the README.

* **Chores**
  * Added editor/validation schema directives to multiple configuration files to improve tooling and schema-aware editing.
  * Introduced a repository-wide SwiftLint configuration to establish linting rules and suppress overlapping formatting rules; TODOs now emit warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->