### PR TITLE
fix(ci): native-release secrets required:false (startup_failure root)

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -33,29 +33,42 @@ on:
         description: 'Version tag to build (e.g. 1.7.0). Required when called.'
         required: true
         type: string
-    # zizmor/secrets-inherit -- enumerate the secrets the called
-    # workflow consumes instead of `secrets: inherit` in release.yml.
-    # When a new signing secret is added to a job below, declare it
-    # here AND mirror it in release.yml's `secrets:` block.
+    # Declared secrets: required: false on every entry.
+    #
+    # Why not required: true: GitHub's workflow-call parser hard-rejects
+    # the calling workflow at PARSE time when any `required: true`
+    # secret is undefined on the repo, even when the calling job has
+    # an `if:` that would skip the call. That's a startup_failure
+    # before any job runs -- the user never sees the helpful error
+    # message from the preflight job below.
+    #
+    # The right enforcement point is the `preflight` job (below),
+    # which has an explicit secret-by-secret check with clear
+    # remediation instructions. Marking required: false here lets
+    # the workflow LOAD; preflight then validates + fails loud with
+    # the actionable error if any secret is empty.
+    #
+    # Adding a new signing secret? Declare it here (required: false)
+    # AND add it to the preflight `for var in ...` loop below.
     secrets:
       APPLE_TEAM_ID:
-        required: true
+        required: false
       MAC_CERTIFICATE:
-        required: true
+        required: false
       MAC_CERTIFICATE_PASSWORD:
-        required: true
+        required: false
       IOS_CERTIFICATE:
-        required: true
+        required: false
       IOS_CERTIFICATE_PASSWORD:
-        required: true
+        required: false
       IOS_PROVISIONING_PROFILE:
-        required: true
+        required: false
       APP_STORE_CONNECT_KEY_ID:
-        required: true
+        required: false
       APP_STORE_CONNECT_ISSUER_ID:
-        required: true
+        required: false
       APP_STORE_CONNECT_PRIVATE_KEY:
-        required: true
+        required: false
 
 # Workflow-level is read-only -- each job declares the writes it
 # genuinely needs (contents: write to attach binaries, id-token /


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `b5f51b0` (run [#280](https://github.com/kaelys-js/heron/actions/runs/26264030355))
<!-- CI-STATUS-MARKER-END -->

## Summary

PR #92 (`secrets: inherit`) was a necessary step but not the actual root cause. `release.yml` still exited `startup_failure` on PR #92's merge commit (`8aa35829`).

## Actual root cause

`native-release.yml`'s `workflow_call.secrets:` block (lines 40-58) declared each Apple signing secret as `required: true`. With the caller now using `secrets: inherit`, the inherited but undefined secrets fail the `required: true` validation at workflow parse time — before any job runs, before the preflight's runtime check can fire its actionable error message.

Chicken-and-egg: the preflight job IS the right enforcement point (clear error + remediation URLs), but it can never execute when `required: true` rejects the workflow_call before startup.

## Fix

Flip every Apple secret declaration from `required: true` → `required: false`. The workflow now LOADS regardless of secret state. The preflight job (lines 76-126) then validates each one at RUNTIME and emits the clear `::error::native-release blocked --` message + remediation URLs the maintainer needs.

Same enforcement, just at a point where the user can actually see why.

## Test plan

- [x] `actionlint` clean on both release.yml + native-release.yml
- [x] `verify-no-slop` clean
- [ ] CI: all 16 required checks pass
- [ ] Post-merge: `release.yml` fires on the merge commit + COMPLETES (no more `startup_failure`)
- [ ] Post-merge: Release Please opens the catch-up release PR titled `chore(main): release v0.2.0`
- [ ] Maintainer reviews + merges that release PR
- [ ] Cascade: native-release.yml LOADS this time + preflight FAILS with the clear secrets-missing message (per Option C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated native release workflow to defer secret validation, enabling clearer error messages and more flexible configuration requirements during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->