### PR TITLE
fix(ci): grant build-natives permissions for workflow_call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,15 @@ jobs:
   # merged), kick off the cross-platform build. workflow_call within the
   # same run means we don't need a PAT.
   #
+  # Permissions: a calling job that uses `uses: ./...` MUST grant >= the
+  # permissions the called workflow's jobs declare, otherwise GitHub fails
+  # the run at PARSE time with "nested job is requesting X but is only
+  # allowed Y". native-release.yml's build-desktop + build-ios both
+  # request contents:write (gh release upload), id-token:write (Sigstore
+  # OIDC), attestations:write (actions/attest-build-provenance). The
+  # top-level `permissions: contents: read` doesn't cascade write access
+  # to this job, so we grant the trio explicitly here.
+  #
   # zizmor: ignore[secrets-inherit]
   # We previously enumerated each Apple signing secret explicitly to satisfy
   # zizmor's secrets-inherit warning, but that pattern hard-fails at workflow
@@ -117,6 +126,10 @@ jobs:
   build-natives:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write # gh release upload + electron-builder publish
+      id-token: write # SLSA / Sigstore provenance via OIDC
+      attestations: write # actions/attest-build-provenance
     uses: ./.github/workflows/native-release.yml
     with:
       version: ${{ needs.release-please.outputs.version }}


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `0f9d899` (run [#282](https://github.com/kaelys-js/heron/actions/runs/26264473431))
<!-- CI-STATUS-MARKER-END -->

## Summary

- release.yml's `build-natives` job inherits the workflow-level `permissions: contents: read`, but native-release.yml's `build-desktop` + `build-ios` both request `contents: write` + `id-token: write` + `attestations: write`. The reusable-workflow validator rejects this mismatch at PARSE time → `startup_failure` with `jobs: []` (run 26264329800, 1s duration, no logs).
- Fix: declare the three writes explicitly on the `build-natives` job. release-please keeps its existing fine-grained writes (contents / pull-requests / issues).

## Why this is the third PR in the cascade

| PR | What it fixed | Was it enough? |
|---|---|---|
| #92 | release.yml `secrets: inherit` | no — still parse error |
| #93 | native-release.yml `workflow_call.secrets.required: false` | no — still parse error |
| **#94 (this)** | `build-natives.permissions:` matches called workflow | yes |

The verbatim error surfaced on run 26264329800:

> The nested job 'build-desktop' is requesting 'attestations: write, contents: write, id-token: write', but is only allowed 'attestations: none, contents: read, id-token: none'.

## Test plan
- [x] actionlint clean on release.yml + native-release.yml
- [x] yamllint clean
- [x] lefthook pre-push (typecheck / vitest / format-check / actionlint / engine-pin / per-commit-conventional / signoff) all green
- [ ] After merge: release.yml run on the merge commit completes without `startup_failure` (release-please job runs; build-natives skipped because `release_created != true` on a non-release-PR-merge)
- [ ] After merge: Release Please opens or updates the catch-up release PR titled `chore(main): release v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow infrastructure with improved permission handling to enable secure artifact uploads and build attestation publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->