### PR TITLE
fix(ci): maintain-discord skip when no token + PR template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/breaking.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking.md
@@ -80,7 +80,7 @@
 - [ ] Migration guide above is complete (someone with no context can follow it)
 - [ ] Updated CHANGELOG.md or relied on Release Please to populate from the BREAKING CHANGE footer
 - [ ] No personal data in the diff
-- [ ] Respects the [Data Contract](../docs/DATA_CONTRACT.md)
+- [ ] Respects the [Data Contract](../../docs/DATA_CONTRACT.md)
 
 ## Notes for reviewers
 

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -44,11 +44,11 @@
 
 ## Checklist
 
-- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [ ] I linked a related issue above (required for features + arch changes)
 - [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
 - [ ] My PR does not include personal data (real CV / email / names / API keys)
-- [ ] My changes respect the [Data Contract](../docs/DATA_CONTRACT.md) (no modifications to user-layer files)
+- [ ] My changes respect the [Data Contract](../../docs/DATA_CONTRACT.md) (no modifications to user-layer files)
 - [ ] If I added a dependency, it's pinned exactly (no `^` / `~`)
 - [ ] If I touched native (iOS / Android / Electron), I ran the platform build locally
 

--- a/.github/PULL_REQUEST_TEMPLATE/feat.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat.md
@@ -48,7 +48,7 @@
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope): …`)
 - [ ] Linked a related issue above
 - [ ] No personal data in the diff (real CV / email / names / API keys)
-- [ ] Respects the [Data Contract](../docs/DATA_CONTRACT.md) (no writes to user-layer files)
+- [ ] Respects the [Data Contract](../../docs/DATA_CONTRACT.md) (no writes to user-layer files)
 - [ ] Any new dependency is pinned exactly (no `^` / `~`)
 - [ ] If native (iOS / Android / Electron) touched, platform build verified locally
 

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -44,7 +44,7 @@
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope): …`)
 - [ ] Linked a related issue above (or justified the skip)
 - [ ] No personal data in the diff
-- [ ] Respects the [Data Contract](../docs/DATA_CONTRACT.md)
+- [ ] Respects the [Data Contract](../../docs/DATA_CONTRACT.md)
 
 ## Notes for reviewers
 

--- a/.github/workflows/maintain-discord.yml
+++ b/.github/workflows/maintain-discord.yml
@@ -97,12 +97,26 @@ jobs:
           echo "mode=$m" >> "$GITHUB_OUTPUT"
           echo "::notice::Reconciler mode: $m"
 
+      # Skip cleanly when DISCORD_BOT_TOKEN isn't configured -- a fresh
+      # fork without Discord setup gets a green workflow with a
+      # ":notice::" annotation rather than a red failure. Once the
+      # maintainer sets the secret (pnpm setup:native step 14), the
+      # reconciler runs in earnest.
+      #
+      # Secret presence is exposed via env on the step, then checked at
+      # runtime in bash -- GitHub Actions disallows `secrets.*` in
+      # step-level `if:` expressions.
       - name: Run apply-discord-config.mjs
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
         run: |
           set -euo pipefail
+          if [ -z "${DISCORD_BOT_TOKEN:-}" ]; then
+            echo "::notice::Discord reconciler skipped -- DISCORD_BOT_TOKEN not configured."
+            echo "Configure via 'pnpm setup:native' step 14, or set the secret manually."
+            exit 0
+          fi
           flag=""
           case "${{ steps.mode.outputs.mode }}" in
             verify) flag="--verify" ;;


### PR DESCRIPTION
<!-- CI-STATUS-MARKER-START -->
> **Latest CI**: ✅ Passed on `e8286d5` (run [#297](https://github.com/kaelys-js/heron/actions/runs/26282784788))
<!-- CI-STATUS-MARKER-END -->

## Motivation

Two CI failures fired on the post-merge run for PR #96 (commit `4ac1d78`):

1. **Maintain Discord** -- the workflow ran `apply-discord-config.mjs`
   unconditionally; the reconciler fails fast when `DISCORD_BOT_TOKEN`
   is absent (correct script behavior). The maintainer hasn't
   configured Discord on this fork yet -- intentional, per the
   deferred-config plan in PR #96. The workflow should stay green
   until the secret is set.

2. **Link check (lychee)** -- 4 broken relative paths in the
   `.github/PULL_REQUEST_TEMPLATE/{breaking,default,feat,fix}.md`
   variants. Pre-existing bug from the PR template rename in PR #95;
   lychee never caught it earlier because it's push:main-triggered
   only.

## Summary

- `.github/workflows/maintain-discord.yml`: bash-level token presence
  check in the run step. Emits `::notice::` + `exit 0` when the
  secret is empty. Once `pnpm setup:native` step 14 lands the token,
  the reconciler runs in earnest.

- `.github/PULL_REQUEST_TEMPLATE/*.md`: fix two relative-path patterns
  - `CONTRIBUTING.md` -> `../CONTRIBUTING.md`
  - `../docs/DATA_CONTRACT.md` -> `../../docs/DATA_CONTRACT.md`

## Test plan

- [x] `actionlint .github/workflows/maintain-discord.yml` -- clean
- [x] PR template paths verified against on-disk targets
- [ ] CI green on this PR (link-check + Maintain Discord)

Closes #97 (was tracking the test-coverage push -- this post-merge
fix is part of the same scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected relative paths in PR template documentation links across breaking-change, default, feature, and fix templates.

* **Chores**
  * Added conditional execution guard to Discord workflow that skips reconciliation when required credentials are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->