### PR TITLE
fix(ci): repair reminders, discord-security, maintain-discord

### DIFF
--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -182,7 +182,11 @@ categories:
             deny: [SEND_MESSAGES, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS]
             allow: [VIEW_CHANNEL, READ_MESSAGE_HISTORY]
       - name: announcements
-        type: 5 # GUILD_ANNOUNCEMENT
+        # Was type 5 (GUILD_ANNOUNCEMENT) but that needs a COMMUNITY-enabled
+        # guild; Discord 400s its creation otherwise. A locked text channel
+        # (members can't post, maintainers can) serves the same purpose and
+        # webhook release posts work on it. Bump to 5 if Community is enabled.
+        type: 0 # GUILD_TEXT
         topic: 'Maintainer announcements. Reactions only; threads off.'
         overwrites:
           - role: '@everyone'

--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -182,11 +182,7 @@ categories:
             deny: [SEND_MESSAGES, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS]
             allow: [VIEW_CHANNEL, READ_MESSAGE_HISTORY]
       - name: announcements
-        # Was type 5 (GUILD_ANNOUNCEMENT) but that needs a COMMUNITY-enabled
-        # guild; Discord 400s its creation otherwise. A locked text channel
-        # (members can't post, maintainers can) serves the same purpose and
-        # webhook release posts work on it. Bump to 5 if Community is enabled.
-        type: 0 # GUILD_TEXT
+        type: 5 # GUILD_ANNOUNCEMENT
         topic: 'Maintainer announcements. Reactions only; threads off.'
         overwrites:
           - role: '@everyone'

--- a/.github/workflows/discord-security-alerts.yml
+++ b/.github/workflows/discord-security-alerts.yml
@@ -117,17 +117,23 @@ jobs:
           # ---- CodeQL / code-scanning alerts ----
           # `created` filters at the API level isn't supported on this
           # endpoint, so we pull open + filter client-side.
+          # `|| ASSIGN` stays OUTSIDE the $() -- inside it, a partial stdout
+          # before a non-zero exit gets the echo'd '[]' appended, yielding a
+          # two-value blob whose `jq length` prints two lines.
           CQ_ALERTS=$(gh api "/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100" \
             --jq "[.[] | select(.created_at > \"$SINCE\" or .updated_at > \"$SINCE\") | select(.rule.security_severity_level == \"high\" or .rule.security_severity_level == \"critical\" or .rule.severity == \"error\")]" \
-            2>/dev/null || echo '[]')
-          CQ_COUNT=$(echo "$CQ_ALERTS" | jq 'length')
+            2>/dev/null) || CQ_ALERTS='[]'
+          CQ_COUNT=$(jq 'length' <<<"$CQ_ALERTS" 2>/dev/null || echo 0)
+          # Keep it a single integer so the TOTAL arithmetic below can't choke.
+          case "$CQ_COUNT" in '' | *[!0-9]*) CQ_COUNT=0 ;; esac
           echo "::notice::Found $CQ_COUNT new HIGH+ CodeQL alerts."
 
           # ---- Dependabot alerts ----
           DB_ALERTS=$(gh api "/repos/${{ github.repository }}/dependabot/alerts?state=open&per_page=100" \
             --jq "[.[] | select(.created_at > \"$SINCE\" or .updated_at > \"$SINCE\") | select(.security_advisory.severity == \"high\" or .security_advisory.severity == \"critical\")]" \
-            2>/dev/null || echo '[]')
-          DB_COUNT=$(echo "$DB_ALERTS" | jq 'length')
+            2>/dev/null) || DB_ALERTS='[]'
+          DB_COUNT=$(jq 'length' <<<"$DB_ALERTS" 2>/dev/null || echo 0)
+          case "$DB_COUNT" in '' | *[!0-9]*) DB_COUNT=0 ;; esac
           echo "::notice::Found $DB_COUNT new HIGH+ Dependabot alerts."
 
           TOTAL=$((CQ_COUNT + DB_COUNT))

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -28,6 +28,12 @@ on:
 permissions:
   contents: read
 
+# These jobs are gh-only (no PR-head checkout). Without GH_REPO, gh tries
+# to infer the repo from a git remote and dies with "not a git repository".
+# quarterly-audit checks out for `git log`, but the other three don't.
+env:
+  GH_REPO: ${{ github.repository }}
+
 concurrency:
   group: reminders-${{ github.run_id }}
   cancel-in-progress: false

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -208,6 +208,13 @@ export function hasFeature(liveGuild, feature) {
   return Array.isArray(liveGuild?.features) && liveGuild.features.includes(feature);
 }
 
+/** A channel that can't be created on this guild and must be skipped (not
+ *  errored on), per docs/DISCORD.md's feature-gate contract. Today that's
+ *  GUILD_ANNOUNCEMENT (type 5), which Discord 400s on a non-COMMUNITY guild. */
+export function channelGatedOut(channel, liveGuild) {
+  return channel?.type === 5 && !hasFeature(liveGuild, 'COMMUNITY');
+}
+
 // ── Image data + apply state ──────────────────────────────────────
 // Guild image slots and the guild feature each one needs (icon needs
 // none). banner/splash/discovery_splash silently skip if the guild
@@ -851,7 +858,7 @@ export function normalizeWelcome(ws) {
  * Returns map of channel-name -> channel-id for AutoMod + Onboarding
  * + Welcome screen downstream references.
  */
-async function applyChannels(cfg, roleIds, botPerms) {
+async function applyChannels(cfg, roleIds, botPerms, guild) {
   const live = await discord('GET', `/guilds/${GUILD_ID}/channels`);
   const liveByName = new Map(live.map((c) => [c.name, c]));
   const idByName = new Map();
@@ -873,6 +880,12 @@ async function applyChannels(cfg, roleIds, botPerms) {
     }
 
     for (const [chIdx, channel] of (category.channels ?? []).entries()) {
+      // Community-gated channel types (announcement) are skipped with a
+      // notice on a guild that lacks the feature -- never a hard error.
+      if (channelGatedOut(channel, guild)) {
+        console.log(`  channel #${channel.name}: skipped (GUILD_ANNOUNCEMENT needs COMMUNITY)`);
+        continue;
+      }
       const existing = liveByName.get(channel.name);
       const overwrites = (channel.overwrites ?? []).map((ow) => {
         // Allow only the bits the bot can grant; warn (don't fail) on the
@@ -1258,7 +1271,7 @@ async function main() {
   const guild = await applyServer(cfg);
   await applyBotProfile(cfg, botUser);
   const roleIds = await applyRoles(cfg, botPerms, guild);
-  const channelIds = await applyChannels(cfg, roleIds, botPerms);
+  const channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
   await applySystemChannel(cfg, guild, channelIds);
   await applyWidget(cfg, channelIds);
   await applyMemberVerification(cfg, guild);

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -10,6 +10,7 @@ import {
   automodDiffers,
   bitsToPermNames,
   buildInviteUrl,
+  channelGatedOut,
   filterGrantable,
   hasFeature,
   imageDrift,
@@ -178,6 +179,14 @@ it('hasFeature: present / absent / missing array', () => {
   assert.equal(hasFeature({ features: ['BANNER', 'COMMUNITY'] }, 'BANNER'), true);
   assert.equal(hasFeature({ features: ['COMMUNITY'] }, 'BANNER'), false);
   assert.equal(hasFeature({}, 'BANNER'), false);
+});
+it('channelGatedOut: announcement skipped only on a non-COMMUNITY guild', () => {
+  // The bug that hard-failed maintain-discord: type 5 on a guild w/o COMMUNITY.
+  assert.equal(channelGatedOut({ type: 5 }, { features: [] }), true);
+  assert.equal(channelGatedOut({ type: 5 }, { features: ['COMMUNITY'] }), false);
+  // Non-announcement types are never gated here (forum type 15 is allowed).
+  assert.equal(channelGatedOut({ type: 0 }, { features: [] }), false);
+  assert.equal(channelGatedOut({ type: 15 }, { features: [] }), false);
 });
 it('sha256: known vector', () => {
   assert.equal(sha256('abc'), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');


### PR DESCRIPTION
## Summary

Three scheduled/maintenance workflows were failing on every run. Root-caused and fixed each.

- **Cadence reminders** (`reminders.yml`) — 3 of its 4 jobs (release-cadence, issue-stale-pinger, dependency-staleness) call `gh` with no checkout, so `gh` fell back to git-remote resolution and died with `fatal: not a git repository`. Added a workflow-level `GH_REPO` so `gh` targets the repo directly. (quarterly-audit keeps its checkout; it needs `git log`.)
- **Discord security alerts** (`discord-security-alerts.yml`) — `CQ_ALERTS=$(gh api ... || echo '[]')` appended `[]` to any partial stdout when `gh`/`jq` exited non-zero, so `jq length` emitted two lines and `TOTAL=$((CQ_COUNT + DB_COUNT))` blew up (then tripped `set -u`). Moved the fallback outside the substitution and integer-guarded both counts.
- **maintain-discord** (`apply-discord-config.mjs`) — `GUILD_ANNOUNCEMENT` (type 5) channels are COMMUNITY-gated; on a non-Community guild Discord 400s their creation, so the reconciler hard-failed before any later step ran. Per `docs/DISCORD.md`, Community features must be skipped with a notice, never errored. Threaded the live guild into `applyChannels` and skip type-5 channels via a new unit-tested `channelGatedOut()` predicate. **`config.yml` is unchanged** — the announcement channel stays `type: 5` and applies correctly once Community is enabled.

## Test plan

- [x] `node scripts/system/apply-discord-config.test.mjs` — 56/56 (incl. new `channelGatedOut` cases)
- [x] `node scripts/system/verify-discord-config.mjs` — config valid
- [x] `actionlint` clean on both workflows; YAML parses
- [ ] After merge: dispatch `Discord security alerts` to confirm it no longer crashes; next `maintain-discord` run skips the announcement channel gracefully instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI-STATUS-MARKER-START -->
**CI:** ✅ 1 passing
<!-- CI-STATUS-MARKER-END -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of security alerts workflow to handle failures gracefully.
  * Enhanced reminders workflow to reliably identify the repository.
  * Fixed announcement channel creation to prevent errors on unsupported server configurations.

* **Tests**
  * Added test coverage for announcement channel compatibility validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->