### PR TITLE
fix(discord): skip stage-voice channels without COMMUNITY

### DIFF
--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -208,11 +208,15 @@ export function hasFeature(liveGuild, feature) {
   return Array.isArray(liveGuild?.features) && liveGuild.features.includes(feature);
 }
 
+// Channel types Discord only permits on a COMMUNITY guild. Creating them on
+// a guild without the feature 400s -- GUILD_ANNOUNCEMENT (5) with 50035, and
+// GUILD_STAGE_VOICE (13) with 50024. (Forum/media work without COMMUNITY.)
+const COMMUNITY_ONLY_CHANNEL_TYPES = new Set([5, 13]);
+
 /** A channel that can't be created on this guild and must be skipped (not
- *  errored on), per docs/DISCORD.md's feature-gate contract. Today that's
- *  GUILD_ANNOUNCEMENT (type 5), which Discord 400s on a non-COMMUNITY guild. */
+ *  errored on), per docs/DISCORD.md's feature-gate contract. */
 export function channelGatedOut(channel, liveGuild) {
-  return channel?.type === 5 && !hasFeature(liveGuild, 'COMMUNITY');
+  return COMMUNITY_ONLY_CHANNEL_TYPES.has(channel?.type) && !hasFeature(liveGuild, 'COMMUNITY');
 }
 
 // ── Image data + apply state ──────────────────────────────────────
@@ -880,10 +884,12 @@ async function applyChannels(cfg, roleIds, botPerms, guild) {
     }
 
     for (const [chIdx, channel] of (category.channels ?? []).entries()) {
-      // Community-gated channel types (announcement) are skipped with a
-      // notice on a guild that lacks the feature -- never a hard error.
+      // Community-only channel types (announcement, stage voice) are skipped
+      // with a notice on a guild that lacks the feature -- never a hard error.
       if (channelGatedOut(channel, guild)) {
-        console.log(`  channel #${channel.name}: skipped (GUILD_ANNOUNCEMENT needs COMMUNITY)`);
+        console.log(
+          `  channel #${channel.name}: skipped (channel type ${channel.type} needs COMMUNITY)`,
+        );
         continue;
       }
       const existing = liveByName.get(channel.name);

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -180,12 +180,16 @@ it('hasFeature: present / absent / missing array', () => {
   assert.equal(hasFeature({ features: ['COMMUNITY'] }, 'BANNER'), false);
   assert.equal(hasFeature({}, 'BANNER'), false);
 });
-it('channelGatedOut: announcement skipped only on a non-COMMUNITY guild', () => {
-  // The bug that hard-failed maintain-discord: type 5 on a guild w/o COMMUNITY.
+it('channelGatedOut: announcement + stage gated only on a non-COMMUNITY guild', () => {
+  // Both bugs that hard-failed maintain-discord: announcement (5, error 50035)
+  // and stage voice (13, error 50024) on a guild without COMMUNITY.
   assert.equal(channelGatedOut({ type: 5 }, { features: [] }), true);
+  assert.equal(channelGatedOut({ type: 13 }, { features: [] }), true);
   assert.equal(channelGatedOut({ type: 5 }, { features: ['COMMUNITY'] }), false);
-  // Non-announcement types are never gated here (forum type 15 is allowed).
+  assert.equal(channelGatedOut({ type: 13 }, { features: ['COMMUNITY'] }), false);
+  // text/voice/forum are creatable without COMMUNITY -> never gated here.
   assert.equal(channelGatedOut({ type: 0 }, { features: [] }), false);
+  assert.equal(channelGatedOut({ type: 2 }, { features: [] }), false);
   assert.equal(channelGatedOut({ type: 15 }, { features: [] }), false);
 });
 it('sha256: known vector', () => {


### PR DESCRIPTION
## Summary

Follow-up to #124. That PR gated `GUILD_ANNOUNCEMENT` (type 5) channels, which let `maintain-discord` get much further — but it then `400`d creating the stage-voice channel `Maintainer office hours` (`GUILD_STAGE_VOICE`, type 13, error `50024`). Stage channels are **also** COMMUNITY-only.

Generalize `channelGatedOut` from a single type to a set of the Community-only channel types (`{5, 13}`). Forum (15) and media (16) create fine without Community, so they stay ungated. The reconciler now skips both Community-only types with a notice instead of hard-failing — per `docs/DISCORD.md`'s feature-gate contract.

Verified against the failing run: the announcement skip already worked and ~15 channels were created successfully before the stage-voice POST failed. This config uses exactly these two Community-only types, and the later Community-gated phases (verification/onboarding/welcome) already skip, so this completes the fix.

## Test plan

- [x] `node scripts/system/apply-discord-config.test.mjs` — 56/56 (extended `channelGatedOut` to assert type 13 is gated, types 0/2/15 are not)
- [x] `node --check` clean
- [ ] After merge: the push-triggered `maintain-discord` apply completes green (skips `#announcements` + `Maintainer office hours`, reconciles the rest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI-STATUS-MARKER-START -->
**CI:** ✅ 1 passing
<!-- CI-STATUS-MARKER-END -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened guild feature-gating for channel creation by extending validation to properly restrict both announcement and stage voice channel types when the Community feature is not available, ensuring more comprehensive and consistent channel management across guild configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->