### PR TITLE
feat(discord): full IaC provisioning (Community, strict-prune, runbook)

### DIFF
--- a/.github/discord/config.schema.json
+++ b/.github/discord/config.schema.json
@@ -7,6 +7,10 @@
   "additionalProperties": false,
   "required": ["server", "roles", "categories"],
   "properties": {
+    "prune": {
+      "type": "boolean",
+      "description": "Strict source of truth: delete channels/roles/AutoMod rules not declared here. Protected: @everyone + managed roles. Needs an Administrator bot."
+    },
     "server": {
       "type": "object",
       "additionalProperties": false,

--- a/.github/discord/config.schema.json
+++ b/.github/discord/config.schema.json
@@ -23,6 +23,7 @@
         "system_channel": { "type": "string" },
         "rules_channel": { "type": "string" },
         "public_updates_channel": { "type": "string" },
+        "everyone_permissions": { "type": "array", "items": { "type": "string" } },
         "system_channel_flags": { "type": "array", "items": { "type": "string" } },
         "images": {
           "type": "object",

--- a/.github/discord/config.schema.json
+++ b/.github/discord/config.schema.json
@@ -14,7 +14,6 @@
     "server": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },

--- a/.github/discord/config.schema.json
+++ b/.github/discord/config.schema.json
@@ -18,6 +18,8 @@
         "default_message_notifications": { "type": "integer", "enum": [0, 1] },
         "explicit_content_filter": { "type": "integer", "enum": [0, 1, 2] },
         "system_channel": { "type": "string" },
+        "rules_channel": { "type": "string" },
+        "public_updates_channel": { "type": "string" },
         "system_channel_flags": { "type": "array", "items": { "type": "string" } },
         "images": {
           "type": "object",

--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -39,8 +39,10 @@ prune: true
 
 server:
   # Guild-wide settings. Reconciled via PATCH /guilds/{id}.
-  # name + description come from branding/brand.json (displayName + tagline) so
-  # a rebrand propagates here. Add `name:` / `description:` to override.
+  # {{brand.*}} tokens resolve from branding/brand.json at load time, so a
+  # rebrand propagates here. brand.json is the single source of truth.
+  name: '{{brand.displayName}}'
+  description: '{{brand.tagline}}'
   # Verification level (DiscordEnum):
   #   0 NONE     -- anyone can talk
   #   1 LOW      -- verified email required
@@ -56,6 +58,30 @@ server:
   # Explicit content filter (0 DISABLED, 1 MEMBERS_WITHOUT_ROLES, 2 ALL_MEMBERS).
   # ALL_MEMBERS: scan every image/video; safer for the brand register.
   explicit_content_filter: 2
+  # @everyone base permissions -- the reconciler sets the @everyone role to
+  # exactly this set, so anything omitted (Mention @everyone, Create
+  # Expressions, Create Events -- the raid/spam-risky bits Discord nags about)
+  # is denied. This is the declarative answer to Discord's "Stop @everyone
+  # spam" prompt: config is the source of truth, not a one-off UI click.
+  everyone_permissions:
+    - VIEW_CHANNEL
+    - CREATE_INSTANT_INVITE
+    - CHANGE_NICKNAME
+    - SEND_MESSAGES
+    - SEND_MESSAGES_IN_THREADS
+    - CREATE_PUBLIC_THREADS
+    - EMBED_LINKS
+    - ATTACH_FILES
+    - ADD_REACTIONS
+    - USE_EXTERNAL_EMOJIS
+    - USE_EXTERNAL_STICKERS
+    - READ_MESSAGE_HISTORY
+    - USE_APPLICATION_COMMANDS
+    - CONNECT
+    - SPEAK
+    - STREAM
+    - USE_VAD
+    - USE_EMBEDDED_ACTIVITIES
   # Channel that receives join / boost system messages. Resolved to its id.
   system_channel: general
   # COMMUNITY requires a rules channel + a "Community Updates" channel
@@ -92,7 +118,7 @@ server:
 # username/avatar per message. Skipped per webhook if its secret isn't
 # present in the reconciler's environment.
 webhooks:
-  name: Heron
+  name: '{{brand.displayName}}'
   avatar: ui/static/icons/heron-512.png
 
 # ── Bot profile ──────────────────────────────────────────────────────
@@ -109,14 +135,14 @@ bot:
 # account AND meets the predicate (e.g., ≥1 merged PR in the repo).
 roles:
   - name: Maintainer
-    color: '#4a5b6d' # Heron Slate
+    color: '{{brand.colors.primary}}' # Heron Slate
     permissions:
       - ADMINISTRATOR
     hoist: true
     mentionable: false
     icon: ''
   - name: Reviewer
-    color: '#7a8c6d' # Heron Reed
+    color: '{{brand.colors.accentSecondary}}' # Heron Reed
     permissions:
       - MANAGE_MESSAGES
       - MANAGE_THREADS
@@ -126,30 +152,30 @@ roles:
     hoist: true
     mentionable: true
   - name: Triager
-    color: '#c89b4a' # Heron Dawn
+    color: '{{brand.colors.accent}}' # Heron Dawn
     permissions:
       - MANAGE_MESSAGES
       - MANAGE_THREADS
     hoist: true
     mentionable: true
   - name: Contributor
-    color: '#7a8c6d'
+    color: '{{brand.colors.accentSecondary}}'
     permissions: []
     hoist: true
     mentionable: false
     connected_role:
       platform: github
       predicate: 'merged_pr_count >= 1'
-      verified_repo: kaelys-js/heron
+      verified_repo: '{{brand.repo}}'
   - name: Sponsor
-    color: '#c89b4a'
+    color: '{{brand.colors.accent}}'
     permissions: []
     hoist: true
     mentionable: false
     connected_role:
       platform: github
       predicate: 'is_sponsor == true'
-      verified_repo: kaelys-js/heron
+      verified_repo: '{{brand.repo}}'
   - name: Hired
     color: '#8a9b7d' # success-leaning green
     permissions: []
@@ -217,15 +243,15 @@ categories:
     channels:
       - name: introductions
         type: 0
-        topic: "Welcome screen sends new members here. Say hi -- background, what brings you to Heron, what you're job-hunting (or hiring) for."
+        topic: "Welcome screen sends new members here. Say hi -- background, what brings you to {{brand.displayName}}, what you're job-hunting (or hiring) for."
         slowmode: 5
       - name: general
         type: 0
-        topic: 'Chat about Heron, job-hunting, anything related.'
+        topic: 'Chat about {{brand.displayName}}, job-hunting, anything related.'
         slowmode: 0
       - name: off-topic
         type: 0
-        topic: 'Non-Heron chat. Keep it brand-aligned per #rules.'
+        topic: 'Non-{{brand.displayName}} chat. Keep it brand-aligned per #rules.'
         slowmode: 5
       - name: hired-stories
         type: 15 # GUILD_FORUM
@@ -454,13 +480,13 @@ onboarding:
   default_channel_ids: [rules, announcements, introductions]
   mode: 1 # ONBOARDING_ADVANCED (vs 0 ONBOARDING_DEFAULT)
   prompts:
-    - title: 'What brings you to Heron?'
+    - title: 'What brings you to {{brand.displayName}}?'
       type: 0 # MULTIPLE_CHOICE
       single_select: true
       required: true
       options:
         - title: 'Job-hunting'
-          description: 'I want to use Heron to find my next role.'
+          description: 'I want to use {{brand.displayName}} to find my next role.'
           emoji_name: '💼'
           role_ids: ['Member']
           channel_ids: ['support', 'ideas', 'hired-stories']
@@ -481,7 +507,7 @@ onboarding:
       required: false
       options:
         - title: 'Releases'
-          description: 'Ping me on @Member when Heron ships a new version.'
+          description: 'Ping me on @Member when {{brand.displayName}} ships a new version.'
           emoji_name: '📦'
           channel_ids: ['changelog']
         - title: 'Hired stories'

--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -52,6 +52,11 @@ server:
   explicit_content_filter: 2
   # Channel that receives join / boost system messages. Resolved to its id.
   system_channel: general
+  # COMMUNITY requires a rules channel + a "Community Updates" channel
+  # (Discord posts admin notices there). The reconciler enables Community
+  # programmatically using these two; both must be text channels.
+  rules_channel: rules
+  public_updates_channel: mod-updates
   # A SET flag SUPPRESSES that notification. SUPPRESS_GUILD_REMINDER_
   # NOTIFICATIONS is the "send helpful tips for server setup" toggle.
   system_channel_flags:
@@ -326,6 +331,14 @@ categories:
             deny: [VIEW_CHANNEL]
           - role: Maintainer
             allow: [VIEW_CHANNEL, SEND_MESSAGES, MANAGE_MESSAGES, MANAGE_THREADS]
+      - name: mod-updates
+        type: 0
+        topic: "Discord's Community Updates land here (feature unlocks, discovery status). Maintainer-only."
+        overwrites:
+          - role: '@everyone'
+            deny: [VIEW_CHANNEL]
+          - role: Maintainer
+            allow: [VIEW_CHANNEL, SEND_MESSAGES, READ_MESSAGE_HISTORY]
 
   - name: 🔊 VOICE
     position: 5

--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -31,6 +31,12 @@
 # Adding a channel / role / AutoMod rule: edit this file + push to
 # main. The reconciler picks it up on the next run.
 
+# Strict source of truth: when true, anything live but NOT declared below
+# (channels, roles, AutoMod rules) is DELETED on apply. Protected: @everyone
+# + managed roles (bot/integration/booster). `--verify` / `--dry` only report
+# the prune diff. Requires an Administrator bot to manage private channels.
+prune: true
+
 server:
   # Guild-wide settings. Reconciled via PATCH /guilds/{id}.
   name: Heron

--- a/.github/discord/config.yml
+++ b/.github/discord/config.yml
@@ -39,8 +39,8 @@ prune: true
 
 server:
   # Guild-wide settings. Reconciled via PATCH /guilds/{id}.
-  name: Heron
-  description: 'Stand still. Strike well. A patient, local-first thinking partner for career transitions.'
+  # name + description come from branding/brand.json (displayName + tagline) so
+  # a rebrand propagates here. Add `name:` / `description:` to override.
   # Verification level (DiscordEnum):
   #   0 NONE     -- anyone can talk
   #   1 LOW      -- verified email required

--- a/.github/workflows/maintain-discord.yml
+++ b/.github/workflows/maintain-discord.yml
@@ -11,9 +11,10 @@ name: Maintain Discord
 #
 # Required secrets:
 #   DISCORD_BOT_TOKEN  -- bot application token (Developer Portal).
-#                         Bot needs MANAGE_GUILD + MANAGE_CHANNELS +
-#                         MANAGE_ROLES. See docs/DISCORD.md for the
-#                         bot-creation + invite walkthrough.
+#                         Bot needs ADMINISTRATOR for full provisioning
+#                         (private channels + enabling Community + prune);
+#                         a scoped invite only partially provisions. See
+#                         docs/DISCORD.md for the bot-creation + invite walkthrough.
 
 on:
   push:

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -255,8 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
-      contents: read
-      issues: write # opens a rotation reminder when the token is stale
+      issues: write # opens a rotation reminder when the token is stale (issue-only; no contents scope)
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -248,3 +248,57 @@ jobs:
             --title "📦 Renovate backlog: ${OPEN} open PRs" \
             --label "renovate-backlog,maintenance" \
             --body-file /tmp/issue.md
+
+  # ── Discord bot token rotation reminder ──────────────────────────
+  discord-token-rotation:
+    name: Discord bot token rotation reminder (90d cadence)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write # opens a rotation reminder when the token is stale
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Token rotated within 90 days?
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROTATED_AT: ${{ vars.DISCORD_TOKEN_ROTATED_AT }}
+        # The bot token grants Administrator on the guild, so treat it like a
+        # private key. Discord has no rotate API -- this is a manual quarterly
+        # step. The maintainer sets the DISCORD_TOKEN_ROTATED_AT repo variable
+        # (ISO date) on each rotation; we nudge when it is stale or unset.
+        run: |
+          set -euo pipefail
+          if [ -n "${ROTATED_AT:-}" ]; then
+            THEN=$(date -d "$ROTATED_AT" +%s 2>/dev/null || echo 0)
+            if [ "$THEN" -gt 0 ]; then
+              DAYS=$(( ( $(date +%s) - THEN ) / 86400 ))
+              if [ "$DAYS" -lt 90 ]; then
+                echo "::notice::Discord token rotated ${DAYS}d ago (< 90); OK."
+                exit 0
+              fi
+            fi
+          fi
+          EXISTING=$(gh issue list --state open \
+            --search "Rotate the Discord bot token in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::Token-rotation reminder #$EXISTING already open"
+            exit 0
+          fi
+          {
+            printf "The Discord bot token (\`DISCORD_BOT_TOKEN\`) grants **Administrator** on the server, so treat it like a private key and rotate it quarterly.\n\n"
+            printf "Discord has no rotate API, so this is manual:\n\n"
+            printf "1. Developer Portal -> the app -> Bot -> **Reset Token**.\n"
+            printf "2. \`gh secret set DISCORD_BOT_TOKEN --repo %s\`\n" "$GH_REPO"
+            printf "3. \`gh variable set DISCORD_TOKEN_ROTATED_AT --body \"\$(date -u +%%Y-%%m-%%d)\" --repo %s\`\n" "$GH_REPO"
+            printf "4. Re-run **Maintain Discord** (mode=verify) to confirm post-rotation access.\n\n"
+            printf "_Posted by reminders.yml -- close after rotating._\n"
+          } > /tmp/issue.md
+          gh issue create \
+            --title "Rotate the Discord bot token (admin-scoped)" \
+            --label "maintenance" \
+            --body-file /tmp/issue.md

--- a/docs/DISCORD.md
+++ b/docs/DISCORD.md
@@ -4,106 +4,171 @@
 *Part of the [Heron](../README.md) docs.*
 <!-- /AUTO-GENERATED:doc-meta -->
 
-Heron's Discord server is reconciled from a single source of truth,
-[`.github/discord/config.yml`](../.github/discord/config.yml), by
-[`scripts/system/apply-discord-config.mjs`](../scripts/system/apply-discord-config.mjs).
-The [`maintain-discord.yml`](../.github/workflows/maintain-discord.yml)
-workflow runs it on push to `main` (when the config or script changes), on
-a weekly cron (drift sweep), and on manual dispatch.
+Heron's Discord server is **infrastructure-as-code**. The desired state lives
+in one file, [`.github/discord/config.yml`](../.github/discord/config.yml), and
+[`scripts/system/apply-discord-config.mjs`](../scripts/system/apply-discord-config.mjs)
+reconciles the live server to match it. The
+[`maintain-discord.yml`](../.github/workflows/maintain-discord.yml) workflow runs
+it on push to `main` (when the config or script change), on a weekly cron (drift
+sweep), and on manual dispatch.
 
-Edit the config, push to `main`, and the live server converges. No
-clicking around in the Discord UI.
+Edit the config, push to `main`, the live server converges. No clicking around
+in the Discord UI.
+
+## Source of truth + drift
+
+`config.yml` is the single source of truth.
+
+- **Declared resources are reconciled.** Change a managed channel's topic, a
+  role's colour, an AutoMod threshold in the UI, and the next run reverts it.
+  The weekly cron runs `--verify` and fails red if anything drifted.
+- **Strict prune (`prune: true`).** Anything live but *not* declared in
+  `config.yml` -- a channel/role/AutoMod rule someone added by hand -- is
+  **deleted** on the next `apply`. That makes the server exactly what the file
+  says, nothing more. Guardrails: `@everyone` and managed roles (the bot's own,
+  integrations, the booster role) are never touched; child channels are deleted
+  before their categories; and a safety cap refuses a mass-delete that signals a
+  broken/empty config. `--verify` / `--dry` only *report* the prune set.
+- Set `prune: false` to keep it additive (correct declared drift, leave manual
+  additions alone).
 
 ## What it manages
 
 | Area | Details |
 |---|---|
+| Community feature | **Enabled programmatically** (`PATCH` guild `features += COMMUNITY` + rules/updates channels). Needs an Administrator bot -- see below |
 | Server settings | name, description, verification level, default notifications, explicit-content filter, `system_channel_flags` (incl. disabling the "helpful tips for server setup" reminders) |
 | Server images | `icon` always; `banner` / `splash` / `discovery_splash` when the guild owns the feature |
 | System channel | the channel join/boost notices post to (`server.system_channel`) |
 | Server widget | enable + the "invite channel" a widget invite points at |
-| Roles | colour, permissions (least-privilege, see below), hoist, mentionable, `unicode_emoji` / `icon` (ROLE_ICONS), plus hierarchy-order **drift detection** |
-| Channels | category layout, topic, slowmode, and **permission overwrites** (member overwrites + roles you don't declare are preserved) |
-| AutoMod | full rule reconciliation (keywords, regex, presets, thresholds, actions, exempt roles) |
-| Membership screening | the "rules" gate a new member accepts (`rules:` block); needs COMMUNITY |
-| Onboarding + Welcome | the native onboarding flow + welcome screen; need COMMUNITY |
+| Roles | colour, permissions, hoist, mentionable, `unicode_emoji` / `icon` (ROLE_ICONS), plus hierarchy-order drift detection |
+| Channels | category layout, topic, slowmode, permission overwrites (two-pass: base channels, enable Community, then announcement/stage channels) |
+| AutoMod | full rule reconciliation (keywords, regex, presets, thresholds, actions, exempt roles); the bot is auto-granted access to alert channels |
+| Membership screening | the "rules" gate a new member accepts (`rules:` block) |
+| Onboarding + Welcome | the native onboarding flow + welcome screen |
 | Webhooks | name + avatar for each channel's declared `webhook:` secret (never rotates the URL) |
 | Bot profile | the bot's own avatar + banner |
+| Prune | deletes undeclared channels/roles/AutoMod rules (`prune: true`) |
+
+## The bot needs Administrator
+
+Full provisioning requires the bot to hold **Administrator**. This is not
+gratuitous -- three things are impossible without it:
+
+1. **Managing private channels.** Maintainer-only channels deny `@everyone`
+   `VIEW_CHANNEL`. `MANAGE_CHANNELS` does **not** override a VIEW denial -- only
+   Administrator does -- so a scoped bot literally cannot see (let alone edit or
+   set AutoMod alerts on) those channels.
+2. **Enabling Community.** The COMMUNITY feature PATCH `403`s for a scoped bot.
+3. **Strict prune.** Deleting a private channel needs access to it.
+
+Grant it one of two ways:
+
+- **Easiest:** Server Settings -> Roles -> the bot's role -> toggle
+  **Administrator** ON. No re-invite.
+- **Or re-invite** with `permissions=8`:
+  `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot%20applications.commands&permissions=8`
+
+A scoped bot (`MANAGE_ROLES`+`MANAGE_CHANNELS`+`MANAGE_GUILD`, integer
+`1100316934320`) still runs, but only *partially* provisions: public channels +
+non-Community settings. It warns (never hard-fails) on what it can't reach.
+
+> Because the token now grants full server admin, treat it like a private key.
+> `reminders.yml` opens a quarterly rotation reminder (see Token rotation).
+
+## Zero-to-live runbook
+
+Going from no server to fully reconciled. Steps 1-4 + 7 are **manual** (no API
+exists to automate them); everything else is automated.
+
+1. **Create the bot application** (manual). [Discord Developer
+   Portal](https://discord.com/developers/applications) -> New Application ->
+   name it (e.g. `Heron Reconciler`) -> **Bot** -> **Reset Token** (copy it;
+   shown once). Enable **Server Members Intent** if you want member enumeration.
+2. **Invite the bot as Administrator** (manual). OAuth2 -> URL Generator ->
+   scopes `bot` + `applications.commands` -> permission **Administrator** ->
+   open the URL -> install on the guild.
+3. **Drag the bot's role to the top** of Server Settings -> Roles (manual). A
+   bot can only manage roles below its own.
+4. **Create the 3 release webhooks** (manual; the URLs are secrets CI can't
+   mint). Server Settings -> Integrations -> Webhooks -> New Webhook, targeting:
+   `#changelog` -> Releases, `#ci-builds` -> Builds, `#security` -> Security.
+5. **Set the secrets + variables** (automatable via `gh`):
+
+   ```sh
+   gh secret   set DISCORD_BOT_TOKEN        --repo kaelys-js/heron   # from step 1
+   gh variable set DISCORD_GUILD_ID         --body '1507162919421612134' --repo kaelys-js/heron
+   gh variable set DISCORD_TOKEN_ROTATED_AT --body "$(date -u +%Y-%m-%d)" --repo kaelys-js/heron
+   gh secret   set DISCORD_WEBHOOK_RELEASES --repo kaelys-js/heron   # from step 4
+   gh secret   set DISCORD_WEBHOOK_BUILDS   --repo kaelys-js/heron
+   gh secret   set DISCORD_WEBHOOK_SECURITY --repo kaelys-js/heron
+   ```
+
+6. **First reconcile** (automated). `gh workflow run maintain-discord.yml --ref main -f mode=apply`.
+   Creates every category/channel/role/AutoMod rule, enables Community, runs
+   onboarding/welcome/rules, and prunes anything undeclared. Idempotent after.
+7. **Connected Roles** (optional; manual deploy -- see below).
+
+## What's automated vs. manual
+
+| Step | Automated? |
+|---|---|
+| Reconcile the whole server (channels/roles/AutoMod/onboarding/welcome/widget/images) | Yes, fully |
+| Enable Community | Yes, now programmatic (needs Administrator bot) |
+| Prune undeclared resources | Yes, `prune: true` |
+| Release / build / security webhook posts | Yes, workflows |
+| Token-rotation reminder | Reminder yes; the **rotation itself is manual** (no Discord API) |
+| Create the bot application | No -- no API to create a Discord app |
+| Invite the bot / grant Administrator | No -- manual (OAuth / Roles UI) |
+| Create the 3 webhooks | No -- their URLs are secrets |
+| Connected Roles endpoint | Partial -- scaffolded; **you deploy + register it** |
+| Server Tags ("traits") | No -- no public API (see below) |
+
+## Token rotation
+
+The bot token grants Administrator, so rotate it quarterly. Discord has **no
+rotate API** -- it's manual:
+
+1. Developer Portal -> the app -> Bot -> **Reset Token**.
+2. `gh secret set DISCORD_BOT_TOKEN --repo kaelys-js/heron`
+3. `gh variable set DISCORD_TOKEN_ROTATED_AT --body "$(date -u +%Y-%m-%d)" --repo kaelys-js/heron`
+4. Re-run **Maintain Discord** (`mode=verify`) to confirm access.
+
+`reminders.yml` opens a rotation issue when `DISCORD_TOKEN_ROTATED_AT` is unset
+or older than 90 days.
+
+## Connected Roles (auto-`@Contributor`)
+
+Discord's linked-roles let a member earn `@Contributor` by proving a merged PR.
+It needs a small **public HTTP endpoint** Discord calls during linking, so it
+can't be fully automated from CI -- but the scaffold is provided:
+
+- [`scripts/discord/connected-roles/register-metadata.mjs`](../scripts/discord/connected-roles/register-metadata.mjs)
+  -- registers the role-connection metadata schema (run once, with the app token).
+- [`scripts/discord/connected-roles/worker.mjs`](../scripts/discord/connected-roles/worker.mjs)
+  -- a Cloudflare-Worker-style handler: OAuth2 callback -> check the GitHub user
+  has a merged Heron PR -> `PUT` the role-connection metadata.
+
+**Deploy (manual):** set `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` /
+`GH_TOKEN` on the worker, `wrangler deploy` (or any host), then Developer Portal
+-> Linked Roles -> point at the worker URL. Until deployed, assign
+`@Contributor` by hand.
 
 ### Not settable via the API: Server Tags ("traits")
 
-As of May 2026 the Discord **Server Tags** / guild-tag feature (the badge
-members can "wear", and the server identity "traits") has **no public REST
-API**. The only documented surface is read-only on the user side
-(`GET /users/{id}` returns `primary_guild`). Configure tags/traits in the
-Discord client UI: Server Settings -> Engagement -> Server Tag. The
-reconciler intentionally has no code path for it.
-
+The Discord **Server Tags** / guild-tag feature (the badge members "wear") has
+**no public REST API** as of May 2026 -- only a read-only user-side surface
+(`GET /users/{id}.primary_guild`). Configure it in the UI: Server Settings ->
+Engagement -> Server Tag. The reconciler intentionally has no code path for it.
 Source: [Discord Support -- Server Tags](https://support.discord.com/hc/en-us/articles/31444248479639-Server-Tags).
-
-## One-time maintainer prerequisites
-
-The walkthrough is `pnpm setup:native` step 14. The essentials:
-
-1. **Create a bot application** in the
-   [Discord Developer Portal](https://discord.com/developers/applications)
-   and copy its token.
-2. **Invite the bot with the right permissions.** The reconciler needs at
-   minimum `MANAGE_ROLES`, `MANAGE_CHANNELS`, and `MANAGE_GUILD`. The
-   recommended invite integer is **`1100316934320`** (those three plus
-   `MANAGE_WEBHOOKS`, `VIEW_AUDIT_LOG`, `MODERATE_MEMBERS`):
-
-   ```text
-   https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot%20applications.commands&permissions=1100316934320
-   ```
-
-   If the bot lacks the management permissions, the reconciler prints this
-   exact URL and exits before touching anything.
-3. **Drag the bot's role to the top** of Server Settings -> Roles. A bot
-   can only manage roles *below* its own.
-4. **Enable the COMMUNITY feature** (Server Settings -> Enable Community)
-   if you want onboarding, the welcome screen, announcement channels, and
-   the rules gate. Without it, those pieces are skipped with a notice.
-5. **Set the repo secrets + variable:** `DISCORD_BOT_TOKEN` (secret),
-   `DISCORD_GUILD_ID` (variable), and the webhook URLs
-   `DISCORD_WEBHOOK_RELEASES` / `DISCORD_WEBHOOK_BUILDS` /
-   `DISCORD_WEBHOOK_SECURITY` (secrets).
-
-## Least-privilege permissions
-
-A bot can only *grant* permissions it holds itself. The `Maintainer` role
-grants `ADMINISTRATOR`; `Reviewer` / `Triager` grant moderation perms. If
-you invite the bot without those (the recommended posture), the reconciler:
-
-- applies every permission it **can** grant,
-- preserves any elevated bit already set by hand (it never strips a
-  manually granted `ADMINISTRATOR`),
-- prints a `::warning::` naming each bit it could not grant, so you can set
-  it once by hand or re-invite the bot holding it.
-
-The run still succeeds. It does not die on a `50013 Missing Permissions`.
-
-## Feature gates
-
-Some capabilities need a guild feature. When absent, the reconciler skips
-that piece with a `::notice::` (never an error):
-
-| Capability | Feature |
-|---|---|
-| onboarding, welcome screen, rules gate, announcement channels | `COMMUNITY` |
-| server banner | `BANNER` |
-| invite splash | `INVITE_SPLASH` |
-| role icons | `ROLE_ICONS` |
-| discovery splash | `DISCOVERABLE` |
 
 ## Image apply-state
 
-Images are content-hashed so an unchanged asset isn't re-uploaded each
-run (Discord rate-limits bot-avatar edits hard). The state
-(`.image-state.json`, `{sourceSha, discordHash}` per slot) is **not
-committed** -- CI can't push to protected `main` -- and is persisted
-across runs via an `actions/cache` entry in `maintain-discord.yml`. A
-cache eviction costs at most one harmless re-upload.
+Images are content-hashed so an unchanged asset isn't re-uploaded each run
+(Discord rate-limits bot-avatar edits hard). The state (`.image-state.json`,
+`{sourceSha, discordHash}` per slot) is **not committed** -- CI can't push to
+protected `main` -- and is persisted across runs via an `actions/cache` entry in
+`maintain-discord.yml`. A cache eviction costs at most one harmless re-upload.
 
 ## Running it
 
@@ -112,9 +177,10 @@ cache eviction costs at most one harmless re-upload.
 pnpm verify:discord-config
 
 # Manual reconcile (GitHub UI: Actions -> Maintain Discord -> Run):
-#   mode = dry     plan only, no writes (safe to run first)
+#   mode = dry     plan only, no writes (safe to run first; shows the prune set)
 #   mode = verify  report drift, exit non-zero if any
 #   mode = apply   converge the live server to the config
 ```
 
-Drift detection is read-only; `apply` is the only mode that writes.
+Drift detection (`dry` / `verify`) is read-only; `apply` is the only mode that
+writes or deletes.

--- a/scripts/discord/connected-roles/register-metadata.mjs
+++ b/scripts/discord/connected-roles/register-metadata.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * register-metadata.mjs -- one-time registration of the Discord
+ * role-connection metadata schema for Heron's Connected Roles
+ * (auto-`@Contributor`).
+ *
+ * Discord surfaces these fields when a member links their account, and a
+ * "linked role" in Server Settings -> Roles can then require e.g.
+ * `merged_prs >= 1`. The worker (worker.mjs) writes each member's actual
+ * values after GitHub verification.
+ *
+ * Run once (idempotent -- a re-run overwrites the schema):
+ *   DISCORD_CLIENT_ID=<app id> DISCORD_BOT_TOKEN=<token> \
+ *     node scripts/discord/connected-roles/register-metadata.mjs
+ *
+ * Docs: https://discord.com/developers/docs/resources/application-role-connection-metadata
+ */
+const API = 'https://discord.com/api/v10';
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+const TOKEN = process.env.DISCORD_BOT_TOKEN;
+
+if (!CLIENT_ID || !TOKEN) {
+  console.error('DISCORD_CLIENT_ID + DISCORD_BOT_TOKEN env vars are required.');
+  process.exit(2);
+}
+
+// Discord metadata_type: 2 = INTEGER_GREATER_THAN_OR_EQUAL, 7 = BOOLEAN_EQUAL.
+const METADATA = [
+  {
+    key: 'merged_prs',
+    name: 'Merged PRs',
+    description: 'Merged pull requests in kaelys-js/heron',
+    type: 2,
+  },
+  {
+    key: 'is_contributor',
+    name: 'Contributor',
+    description: 'Has at least one merged PR',
+    type: 7,
+  },
+];
+
+const res = await fetch(`${API}/applications/${CLIENT_ID}/role-connections/metadata`, {
+  method: 'PUT',
+  headers: { Authorization: `Bot ${TOKEN}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify(METADATA),
+});
+
+if (!res.ok) {
+  console.error(`Failed to register metadata: ${res.status} ${await res.text()}`);
+  process.exit(1);
+}
+const registered = await res.json();
+console.log(
+  `OK -- registered role-connection metadata: ${registered.map((m) => m.key).join(', ')}`,
+);

--- a/scripts/discord/connected-roles/register-metadata.mjs
+++ b/scripts/discord/connected-roles/register-metadata.mjs
@@ -15,9 +15,19 @@
  *
  * Docs: https://discord.com/developers/docs/resources/application-role-connection-metadata
  */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const API = 'https://discord.com/api/v10';
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const TOKEN = process.env.DISCORD_BOT_TOKEN;
+
+// Repo slug from branding/brand.json (the single source of truth).
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const brand = JSON.parse(readFileSync(join(REPO_ROOT, 'branding', 'brand.json'), 'utf8'));
+const REPO =
+  brand.repo?.owner && brand.repo?.name ? `${brand.repo.owner}/${brand.repo.name}` : 'the repo';
 
 if (!CLIENT_ID || !TOKEN) {
   console.error('DISCORD_CLIENT_ID + DISCORD_BOT_TOKEN env vars are required.');
@@ -29,7 +39,7 @@ const METADATA = [
   {
     key: 'merged_prs',
     name: 'Merged PRs',
-    description: 'Merged pull requests in kaelys-js/heron',
+    description: `Merged pull requests in ${REPO}`,
     type: 2,
   },
   {

--- a/scripts/discord/connected-roles/register-metadata.mjs
+++ b/scripts/discord/connected-roles/register-metadata.mjs
@@ -23,9 +23,15 @@ const API = 'https://discord.com/api/v10';
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const TOKEN = process.env.DISCORD_BOT_TOKEN;
 
-// Repo slug from branding/brand.json (the single source of truth).
+// Repo slug from branding/brand.json (the single source of truth). Tolerate a
+// missing/malformed brand file -- fall back rather than crash the script.
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
-const brand = JSON.parse(readFileSync(join(REPO_ROOT, 'branding', 'brand.json'), 'utf8'));
+let brand = {};
+try {
+  brand = JSON.parse(readFileSync(join(REPO_ROOT, 'branding', 'brand.json'), 'utf8'));
+} catch {
+  console.warn('Could not read branding/brand.json; using a generic repo label.');
+}
 const REPO =
   brand.repo?.owner && brand.repo?.name ? `${brand.repo.owner}/${brand.repo.name}` : 'the repo';
 

--- a/scripts/discord/connected-roles/worker.mjs
+++ b/scripts/discord/connected-roles/worker.mjs
@@ -35,6 +35,12 @@ async function verify(secret, signed) {
   const value = signed.slice(0, i);
   return (await sign(secret, value)) === signed ? value : null;
 }
+/** A returned OAuth state is valid when the signed cookie equals the signed
+ *  URL state AND its signature verifies. (Comparing verify()'s unsigned return
+ *  to the signed URL value would never match.) */
+async function stateOk(secret, cookieState, urlState) {
+  return !!cookieState && cookieState === urlState && (await verify(secret, cookieState)) !== null;
+}
 function cookie(name, value, maxAge = 600) {
   return `${name}=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
 }
@@ -82,8 +88,11 @@ export default {
     // 2. Discord callback -> stash the Discord token, bounce to GitHub OAuth.
     if (url.pathname === '/discord-callback') {
       if (
-        (await verify(env.COOKIE_SECRET, readCookie(req, 'd_state'))) !==
-        url.searchParams.get('state')
+        !(await stateOk(
+          env.COOKIE_SECRET,
+          readCookie(req, 'd_state'),
+          url.searchParams.get('state'),
+        ))
       )
         return new Response('bad state', { status: 400 });
       const tok = await exchange(`${DISCORD_API}/oauth2/token`, {
@@ -110,8 +119,11 @@ export default {
     // 3. GitHub callback -> verify contributor, write role-connection metadata.
     if (url.pathname === '/github-callback') {
       if (
-        (await verify(env.COOKIE_SECRET, readCookie(req, 'g_state'))) !==
-        url.searchParams.get('state')
+        !(await stateOk(
+          env.COOKIE_SECRET,
+          readCookie(req, 'g_state'),
+          url.searchParams.get('state'),
+        ))
       )
         return new Response('bad state', { status: 400 });
       const discordToken = await verify(env.COOKIE_SECRET, readCookie(req, 'd_token'));
@@ -128,15 +140,17 @@ export default {
         Authorization: `Bearer ${ghTok.access_token}`,
         'User-Agent': 'heron-connected-roles',
       };
-      const ghUser = await (
-        await fetch('https://api.github.com/user', { headers: ghHeaders })
-      ).json();
-      const search = await (
-        await fetch(
-          `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${env.REPO} type:pr author:${ghUser.login} is:merged`)}`,
-          { headers: ghHeaders },
-        )
-      ).json();
+      const userRes = await fetch('https://api.github.com/user', { headers: ghHeaders });
+      if (!userRes.ok)
+        return new Response(`GitHub /user failed: ${userRes.status}`, { status: 502 });
+      const ghUser = await userRes.json();
+      const searchRes = await fetch(
+        `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${env.REPO} type:pr author:${ghUser.login} is:merged`)}`,
+        { headers: ghHeaders },
+      );
+      if (!searchRes.ok)
+        return new Response(`GitHub search failed: ${searchRes.status}`, { status: 502 });
+      const search = await searchRes.json();
       const mergedPrs = search.total_count ?? 0;
 
       const put = await fetch(

--- a/scripts/discord/connected-roles/worker.mjs
+++ b/scripts/discord/connected-roles/worker.mjs
@@ -1,0 +1,171 @@
+/**
+ * worker.mjs -- Connected Roles endpoint scaffold (auto-`@Contributor`).
+ *
+ * SCAFFOLD: review security + test before production. Discord linked-roles via
+ * a Discord + GitHub double-OAuth (/linked-role -> /discord-callback ->
+ * /github-callback): counts merged Heron PRs, writes the member's
+ * role-connection metadata with HMAC-signed state. Deploy + register per
+ * docs/DISCORD.md; run register-metadata.mjs first. Env: DISCORD_CLIENT_ID/
+ * SECRET, GITHUB_CLIENT_ID/SECRET, COOKIE_SECRET, BASE_URL.
+ */
+
+const DISCORD_API = 'https://discord.com/api/v10';
+const REPO = 'kaelys-js/heron';
+const enc = new TextEncoder();
+
+// ── HMAC-signed state (CSRF) ──────────────────────────────────────
+async function hmacKey(secret) {
+  return crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  );
+}
+async function sign(secret, value) {
+  const key = await hmacKey(secret);
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(value));
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(sig)));
+  return `${value}.${b64}`;
+}
+async function verify(secret, signed) {
+  const i = (signed || '').lastIndexOf('.');
+  if (i < 0) return null;
+  const value = signed.slice(0, i);
+  return (await sign(secret, value)) === signed ? value : null;
+}
+function cookie(name, value, maxAge = 600) {
+  return `${name}=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
+}
+function readCookie(req, name) {
+  const m = (req.headers.get('Cookie') || '').match(new RegExp(`(?:^|; )${name}=([^;]+)`));
+  return m ? decodeURIComponent(m[1]) : null;
+}
+function redirect(url, setCookies = []) {
+  const headers = new Headers({ Location: url });
+  for (const c of setCookies) headers.append('Set-Cookie', c);
+  return new Response(null, { status: 302, headers });
+}
+
+// ── OAuth helpers ─────────────────────────────────────────────────
+async function exchange(tokenUrl, params) {
+  const res = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: new URLSearchParams(params),
+  });
+  if (!res.ok) throw new Error(`token exchange ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    const redirectUri = `${env.BASE_URL}`;
+
+    // 1. Start: redirect to Discord OAuth (identify + role_connections.write).
+    if (url.pathname === '/linked-role') {
+      const state = await sign(env.COOKIE_SECRET, crypto.randomUUID());
+      const auth = new URL('https://discord.com/oauth2/authorize');
+      auth.search = new URLSearchParams({
+        client_id: env.DISCORD_CLIENT_ID,
+        redirect_uri: `${redirectUri}/discord-callback`,
+        response_type: 'code',
+        scope: 'identify role_connections.write',
+        state,
+        prompt: 'consent',
+      }).toString();
+      return redirect(auth.toString(), [cookie('d_state', state)]);
+    }
+
+    // 2. Discord callback -> stash the Discord token, bounce to GitHub OAuth.
+    if (url.pathname === '/discord-callback') {
+      if (
+        (await verify(env.COOKIE_SECRET, readCookie(req, 'd_state'))) !==
+        url.searchParams.get('state')
+      )
+        return new Response('bad state', { status: 400 });
+      const tok = await exchange(`${DISCORD_API}/oauth2/token`, {
+        client_id: env.DISCORD_CLIENT_ID,
+        client_secret: env.DISCORD_CLIENT_SECRET,
+        grant_type: 'authorization_code',
+        code: url.searchParams.get('code'),
+        redirect_uri: `${redirectUri}/discord-callback`,
+      });
+      const gState = await sign(env.COOKIE_SECRET, crypto.randomUUID());
+      const gh = new URL('https://github.com/login/oauth/authorize');
+      gh.search = new URLSearchParams({
+        client_id: env.GITHUB_CLIENT_ID,
+        redirect_uri: `${redirectUri}/github-callback`,
+        scope: 'read:user',
+        state: gState,
+      }).toString();
+      return redirect(gh.toString(), [
+        cookie('d_token', await sign(env.COOKIE_SECRET, tok.access_token)),
+        cookie('g_state', gState),
+      ]);
+    }
+
+    // 3. GitHub callback -> verify contributor, write role-connection metadata.
+    if (url.pathname === '/github-callback') {
+      if (
+        (await verify(env.COOKIE_SECRET, readCookie(req, 'g_state'))) !==
+        url.searchParams.get('state')
+      )
+        return new Response('bad state', { status: 400 });
+      const discordToken = await verify(env.COOKIE_SECRET, readCookie(req, 'd_token'));
+      if (!discordToken)
+        return new Response('session expired; restart at /linked-role', { status: 400 });
+
+      const ghTok = await exchange('https://github.com/login/oauth/access_token', {
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        code: url.searchParams.get('code'),
+        redirect_uri: `${redirectUri}/github-callback`,
+      });
+      const ghHeaders = {
+        Authorization: `Bearer ${ghTok.access_token}`,
+        'User-Agent': 'heron-connected-roles',
+      };
+      const ghUser = await (
+        await fetch('https://api.github.com/user', { headers: ghHeaders })
+      ).json();
+      const search = await (
+        await fetch(
+          `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} type:pr author:${ghUser.login} is:merged`)}`,
+          { headers: ghHeaders },
+        )
+      ).json();
+      const mergedPrs = search.total_count ?? 0;
+
+      const put = await fetch(
+        `${DISCORD_API}/users/@me/applications/${env.DISCORD_CLIENT_ID}/role-connection`,
+        {
+          method: 'PUT',
+          headers: { Authorization: `Bearer ${discordToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            platform_name: 'GitHub',
+            platform_username: ghUser.login,
+            metadata: { merged_prs: mergedPrs, is_contributor: mergedPrs > 0 ? 1 : 0 },
+          }),
+        },
+      );
+      if (!put.ok)
+        return new Response(`role-connection write failed: ${await put.text()}`, { status: 502 });
+      const done = new Headers();
+      for (const c of [
+        cookie('d_token', '', 0),
+        cookie('g_state', '', 0),
+        cookie('d_state', '', 0),
+      ])
+        done.append('Set-Cookie', c);
+      return new Response(
+        `Linked ${ghUser.login}: ${mergedPrs} merged PR(s). You can close this tab and claim the role in Discord.`,
+        { headers: done },
+      );
+    }
+
+    return new Response('Heron Connected Roles. Start at /linked-role.', { status: 404 });
+  },
+};

--- a/scripts/discord/connected-roles/worker.mjs
+++ b/scripts/discord/connected-roles/worker.mjs
@@ -6,11 +6,11 @@
  * /github-callback): counts merged Heron PRs, writes the member's
  * role-connection metadata with HMAC-signed state. Deploy + register per
  * docs/DISCORD.md; run register-metadata.mjs first. Env: DISCORD_CLIENT_ID/
- * SECRET, GITHUB_CLIENT_ID/SECRET, COOKIE_SECRET, BASE_URL.
+ * SECRET, GITHUB_CLIENT_ID/SECRET, COOKIE_SECRET, BASE_URL, REPO (owner/name
+ * from brand.json::repo).
  */
 
 const DISCORD_API = 'https://discord.com/api/v10';
-const REPO = 'kaelys-js/heron';
 const enc = new TextEncoder();
 
 // ── HMAC-signed state (CSRF) ──────────────────────────────────────
@@ -133,7 +133,7 @@ export default {
       ).json();
       const search = await (
         await fetch(
-          `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} type:pr author:${ghUser.login} is:merged`)}`,
+          `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${env.REPO} type:pr author:${ghUser.login} is:merged`)}`,
           { headers: ghHeaders },
         )
       ).json();
@@ -166,6 +166,6 @@ export default {
       );
     }
 
-    return new Response('Heron Connected Roles. Start at /linked-role.', { status: 404 });
+    return new Response('Connected Roles endpoint. Start at /linked-role.', { status: 404 });
   },
 };

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -612,12 +612,14 @@ async function applyServer(cfg) {
   // name + description come from config.yml's {{brand.*}} tokens, already
   // resolved against brand.json in loadConfig (single source of truth).
   const desired = {
-    name: cfg.server.name,
-    description: cfg.server.description ?? '',
     verification_level: cfg.server.verification_level,
     default_message_notifications: cfg.server.default_message_notifications,
     explicit_content_filter: cfg.server.explicit_content_filter,
   };
+  // Only manage name/description when set, so a missing/partial brand.json
+  // (token -> '') never clears the live server identity.
+  if (cfg.server.name) desired.name = cfg.server.name;
+  if (cfg.server.description) desired.description = cfg.server.description;
   if (cfg.server.system_channel_flags) {
     desired.system_channel_flags = systemChannelFlagsToBits(cfg.server.system_channel_flags);
   }
@@ -1092,10 +1094,12 @@ async function ensureCommunity(cfg, guild, channelIds) {
   const rulesId = rulesName ? channelIds.get(rulesName) : null;
   const updatesId = updatesName ? channelIds.get(updatesName) : null;
   if (!rulesId || !updatesId) {
-    logManual(
-      `COMMUNITY not enabled: needs text channels server.rules_channel ("${rulesName}") + server.public_updates_channel ("${updatesName}") to exist first.`,
+    // Fail loud: COMMUNITY is required by config (gated channels/onboarding/
+    // rules depend on it), so a missing rules/updates channel is a real
+    // misconfig, not something to skip and "succeed" past.
+    throw new Error(
+      `COMMUNITY cannot be enabled: server.rules_channel ("${rulesName}") + server.public_updates_channel ("${updatesName}") must name existing text channels.`,
     );
-    return { guild, justEnabled: false };
   }
   logChange('server.features', (guild.features ?? []).join(', ') || '(none)', 'COMMUNITY');
   const updated = await discord(
@@ -1460,10 +1464,12 @@ async function pruneUndeclared(cfg) {
     return;
   }
   if (total > PRUNE_SAFETY_CAP) {
-    logManual(
+    // Fail loud rather than silently no-op: a prune set this large almost
+    // always means a broken/empty config, and a quiet return would let verify
+    // pass green while real drift goes unactioned.
+    throw new Error(
       `prune: ${total} undeclared resources exceed the safety cap (${PRUNE_SAFETY_CAP}); refusing to mass-delete. Check config.yml parsed correctly.`,
     );
-    return;
   }
   for (const c of chPrune) {
     logChange(`prune channel #${c.name}`, 'live', 'deleted');

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -213,10 +213,38 @@ export function hasFeature(liveGuild, feature) {
 // GUILD_STAGE_VOICE (13) with 50024. (Forum/media work without COMMUNITY.)
 const COMMUNITY_ONLY_CHANNEL_TYPES = new Set([5, 13]);
 
-/** A channel that can't be created on this guild and must be skipped (not
- *  errored on), per docs/DISCORD.md's feature-gate contract. */
+/** A channel that can't be created yet because COMMUNITY isn't on. The
+ *  reconciler enables COMMUNITY (see ensureCommunity) once the rules +
+ *  updates channels exist, then a second channel pass creates these. So this
+ *  holds them for pass 2 within the same run -- it is not a give-up skip. */
 export function channelGatedOut(channel, liveGuild) {
   return COMMUNITY_ONLY_CHANNEL_TYPES.has(channel?.type) && !hasFeature(liveGuild, 'COMMUNITY');
+}
+
+/** PATCH body that turns on COMMUNITY: the feature flag plus a rules + a
+ *  public-updates text channel (both required by Discord). verification_level
+ *  + explicit_content_filter must already meet Community minimums -- applyServer
+ *  sets them from config (Heron uses MEDIUM + ALL_MEMBERS), so they're not
+ *  re-sent here. */
+export function buildCommunityPatch(liveGuild, rulesChannelId, updatesChannelId) {
+  return {
+    features: Array.from(new Set([...(liveGuild?.features ?? []), 'COMMUNITY'])),
+    rules_channel_id: rulesChannelId,
+    public_updates_channel_id: updatesChannelId,
+  };
+}
+
+/** Channel names an AutoMod rule alerts to (SEND_ALERT_MESSAGE = action type
+ *  2). The bot needs View + Send on each or Discord rejects the rule with
+ *  INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS. */
+export function alertChannelNames(cfg) {
+  const names = new Set();
+  for (const rule of cfg?.automod ?? []) {
+    for (const action of rule.actions ?? []) {
+      if (action.type === 2 && action.metadata?.channel) names.add(action.metadata.channel);
+    }
+  }
+  return [...names];
 }
 
 // ── Image data + apply state ──────────────────────────────────────
@@ -884,11 +912,12 @@ async function applyChannels(cfg, roleIds, botPerms, guild) {
     }
 
     for (const [chIdx, channel] of (category.channels ?? []).entries()) {
-      // Community-only channel types (announcement, stage voice) are skipped
-      // with a notice on a guild that lacks the feature -- never a hard error.
+      // Community-only channel types (announcement, stage voice) wait for
+      // pass 2; ensureCommunity turns COMMUNITY on, then the second pass
+      // creates them. This holds within the run -- it does not give up.
       if (channelGatedOut(channel, guild)) {
         console.log(
-          `  channel #${channel.name}: skipped (channel type ${channel.type} needs COMMUNITY)`,
+          `  channel #${channel.name}: held for pass 2 (needs COMMUNITY, type ${channel.type})`,
         );
         continue;
       }
@@ -959,6 +988,67 @@ async function applyChannels(cfg, roleIds, botPerms, guild) {
     }
   }
   return idByName;
+}
+
+/**
+ * Enable the COMMUNITY feature programmatically so announcement / stage
+ * channels, onboarding, the welcome screen, and the rules gate can be
+ * provisioned (not skipped). No-op if already on. Needs the rules +
+ * public-updates text channels to exist (created in the first channel pass).
+ * Returns { guild, justEnabled } -- justEnabled triggers a second channel
+ * pass for the now-unlocked types.
+ */
+async function ensureCommunity(cfg, guild, channelIds) {
+  if (hasFeature(guild, 'COMMUNITY')) return { guild, justEnabled: false };
+  const rulesName = cfg.server?.rules_channel;
+  const updatesName = cfg.server?.public_updates_channel;
+  const rulesId = rulesName ? channelIds.get(rulesName) : null;
+  const updatesId = updatesName ? channelIds.get(updatesName) : null;
+  if (!rulesId || !updatesId) {
+    logManual(
+      `COMMUNITY not enabled: needs text channels server.rules_channel ("${rulesName}") + server.public_updates_channel ("${updatesName}") to exist first.`,
+    );
+    return { guild, justEnabled: false };
+  }
+  logChange('server.features', (guild.features ?? []).join(', ') || '(none)', 'COMMUNITY');
+  const updated = await discord(
+    'PATCH',
+    `/guilds/${GUILD_ID}`,
+    buildCommunityPatch(guild, rulesId, updatesId),
+  );
+  // verify/dry stub the PATCH (updated === null) -> report only, no 2nd pass.
+  if (!updated) return { guild, justEnabled: false };
+  return { guild: updated, justEnabled: true };
+}
+
+/** The bot's own managed (integration) role -- the one Discord auto-creates
+ *  for the bot app. Needed to grant the bot channel access it lacks. */
+async function getBotRoleId(botUserId) {
+  const roles = await discord('GET', `/guilds/${GUILD_ID}/roles`);
+  return (roles ?? []).find((r) => r.tags?.bot_id === botUserId)?.id ?? null;
+}
+
+/** Grant the bot View + Send on every AutoMod alert channel, so rule creation
+ *  doesn't 400 with INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS. PUT is
+ *  idempotent -- it sets (creates or updates) the bot-role overwrite. */
+async function ensureBotAlertAccess(cfg, channelIds, botRoleId) {
+  const targets = alertChannelNames(cfg);
+  if (targets.length === 0) return;
+  if (!botRoleId) {
+    logManual('Cannot grant bot access to AutoMod alert channels: bot role not found.');
+    return;
+  }
+  const allow = (PERM.VIEW_CHANNEL | PERM.SEND_MESSAGES).toString();
+  for (const name of targets) {
+    const chId = channelIds.get(name);
+    if (!chId) continue;
+    await discord('PUT', `/channels/${chId}/permissions/${botRoleId}`, {
+      type: 0, // role overwrite
+      allow,
+      deny: '0',
+    });
+    logOk(`bot access -> #${name} (AutoMod alert target)`);
+  }
 }
 
 /**
@@ -1274,10 +1364,23 @@ async function main() {
   imageState = loadImageState();
   const { botUser, botPerms } = await preflight();
 
-  const guild = await applyServer(cfg);
+  let guild = await applyServer(cfg);
   await applyBotProfile(cfg, botUser);
   const roleIds = await applyRoles(cfg, botPerms, guild);
-  const channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
+  // First channel pass creates everything except the COMMUNITY-only types
+  // (announcement / stage), which wait for pass 2. That guarantees the rules +
+  // public-updates channels exist for the COMMUNITY enable below.
+  let channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
+  const community = await ensureCommunity(cfg, guild, channelIds);
+  guild = community.guild;
+  // COMMUNITY just turned on -> a second pass now creates those held types
+  // and the newly reachable phases (rules gate / onboarding / welcome) below
+  // provision instead of skipping.
+  if (community.justEnabled) {
+    channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
+  }
+  // Grant the bot access to AutoMod alert channels before creating the rules.
+  await ensureBotAlertAccess(cfg, channelIds, await getBotRoleId(botUser.id));
   await applySystemChannel(cfg, guild, channelIds);
   await applyWidget(cfg, channelIds);
   await applyMemberVerification(cfg, guild);

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -384,7 +384,9 @@ function loadConfig() {
   if (!existsSync(CONFIG_PATH)) {
     throw new Error(`Config not found at ${CONFIG_PATH}`);
   }
-  return yaml.load(readFileSync(CONFIG_PATH, 'utf8'));
+  // Resolve {{brand.*}} tokens so brand.json is the single source of truth for
+  // every identity value embedded in the config (name, tagline, colors, repo).
+  return resolveBrandTokens(yaml.load(readFileSync(CONFIG_PATH, 'utf8')), loadBrand());
 }
 
 // branding/brand.json is the single source of truth for identity (name,
@@ -400,6 +402,26 @@ export function loadBrand() {
 export function brandRepoSlug(brand = loadBrand()) {
   const r = brand?.repo;
   return r?.owner && r?.name ? `${r.owner}/${r.name}` : '';
+}
+
+/** Replace every {{brand.PATH}} token in a parsed config's strings with the
+ *  value from brand.json (dot-path lookup; {{brand.repo}} -> owner/name slug).
+ *  Unknown tokens resolve to '' so a typo is visible, not a literal brace. */
+export function resolveBrandTokens(value, brand = loadBrand()) {
+  if (typeof value === 'string') {
+    return value.replace(/\{\{brand\.([\w.]+)\}\}/g, (_, path) => {
+      if (path === 'repo') return brandRepoSlug(brand);
+      const v = path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), brand);
+      return v == null ? '' : String(v);
+    });
+  }
+  if (Array.isArray(value)) return value.map((v) => resolveBrandTokens(v, brand));
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[k] = resolveBrandTokens(v, brand);
+    return out;
+  }
+  return value;
 }
 
 function resolveGuildId() {
@@ -587,12 +609,11 @@ async function applyServer(cfg) {
   const patch = {};
 
   // ── scalar settings ──
-  // Identity (name + description) is sourced from branding/brand.json so a
-  // rebrand propagates here automatically; config.yml may override.
-  const brand = loadBrand();
+  // name + description come from config.yml's {{brand.*}} tokens, already
+  // resolved against brand.json in loadConfig (single source of truth).
   const desired = {
-    name: cfg.server.name ?? brand.displayName ?? brand.name,
-    description: cfg.server.description ?? brand.tagline ?? brand.description ?? '',
+    name: cfg.server.name,
+    description: cfg.server.description ?? '',
     verification_level: cfg.server.verification_level,
     default_message_notifications: cfg.server.default_message_notifications,
     explicit_content_filter: cfg.server.explicit_content_filter,
@@ -1458,6 +1479,29 @@ async function pruneUndeclared(cfg) {
   }
 }
 
+/**
+ * Set the @everyone base permissions to exactly cfg.server.everyone_permissions,
+ * so omitted bits (Mention @everyone, Create Expressions, Create Events) are
+ * denied -- the declarative form of Discord's "Stop @everyone spam" prompt.
+ * The @everyone role's id equals the guild id.
+ */
+async function applyEveryonePermissions(cfg) {
+  const allow = cfg.server?.everyone_permissions;
+  if (!Array.isArray(allow)) {
+    logOk('@everyone permissions (not declared)');
+    return;
+  }
+  const desired = permsToBits(allow).toString();
+  const roles = (await discord('GET', `/guilds/${GUILD_ID}/roles`)) ?? [];
+  const everyone = roles.find((r) => r.id === GUILD_ID);
+  if (everyone && everyone.permissions === desired) {
+    logOk('@everyone permissions');
+    return;
+  }
+  logChange('@everyone permissions', everyone?.permissions ?? '?', desired);
+  await discord('PATCH', `/guilds/${GUILD_ID}/roles/${GUILD_ID}`, { permissions: desired });
+}
+
 // ── Main ──────────────────────────────────────────────────────────
 async function main() {
   TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -1481,6 +1525,7 @@ async function main() {
   let guild = await applyServer(cfg);
   await applyBotProfile(cfg, botUser);
   const roleIds = await applyRoles(cfg, botPerms, guild);
+  await applyEveryonePermissions(cfg);
   // First channel pass creates everything except the COMMUNITY-only types
   // (announcement / stage), which wait for pass 2. That guarantees the rules +
   // public-updates channels exist for the COMMUNITY enable below.

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -1028,14 +1028,18 @@ async function getBotRoleId(botUserId) {
   return (roles ?? []).find((r) => r.tags?.bot_id === botUserId)?.id ?? null;
 }
 
-/** Grant the bot View + Send on every AutoMod alert channel, so rule creation
- *  doesn't 400 with INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS. PUT is
- *  idempotent -- it sets (creates or updates) the bot-role overwrite. */
-async function ensureBotAlertAccess(cfg, channelIds, botRoleId) {
-  const targets = alertChannelNames(cfg);
+/** Grant the bot View + Send on the named channels via a role overwrite, so
+ *  the bot can reach channels Discord requires it to access:
+ *   - AutoMod alert targets (else rule creation 400s
+ *     INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS), and
+ *   - the COMMUNITY rules + public-updates channels (else the enable PATCH
+ *     403s Missing Access when one is a channel the bot can't see).
+ *  PUT is idempotent -- it sets (creates or updates) the bot-role overwrite. */
+async function ensureBotChannelAccess(channelIds, botRoleId, names, label) {
+  const targets = [...new Set(names)].filter(Boolean);
   if (targets.length === 0) return;
   if (!botRoleId) {
-    logManual('Cannot grant bot access to AutoMod alert channels: bot role not found.');
+    logManual(`Cannot grant bot access to ${label} channels: bot role not found.`);
     return;
   }
   const allow = (PERM.VIEW_CHANNEL | PERM.SEND_MESSAGES).toString();
@@ -1047,7 +1051,7 @@ async function ensureBotAlertAccess(cfg, channelIds, botRoleId) {
       allow,
       deny: '0',
     });
-    logOk(`bot access -> #${name} (AutoMod alert target)`);
+    logOk(`bot access -> #${name} (${label})`);
   }
 }
 
@@ -1371,6 +1375,15 @@ async function main() {
   // (announcement / stage), which wait for pass 2. That guarantees the rules +
   // public-updates channels exist for the COMMUNITY enable below.
   let channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
+  const botRoleId = await getBotRoleId(botUser.id);
+  // The COMMUNITY enable PATCH 403s if the bot can't see the rules / updates
+  // channels it names, so grant access first.
+  await ensureBotChannelAccess(
+    channelIds,
+    botRoleId,
+    [cfg.server?.rules_channel, cfg.server?.public_updates_channel],
+    'COMMUNITY channel',
+  );
   const community = await ensureCommunity(cfg, guild, channelIds);
   guild = community.guild;
   // COMMUNITY just turned on -> a second pass now creates those held types
@@ -1380,7 +1393,7 @@ async function main() {
     channelIds = await applyChannels(cfg, roleIds, botPerms, guild);
   }
   // Grant the bot access to AutoMod alert channels before creating the rules.
-  await ensureBotAlertAccess(cfg, channelIds, await getBotRoleId(botUser.id));
+  await ensureBotChannelAccess(channelIds, botRoleId, alertChannelNames(cfg), 'AutoMod alert');
   await applySystemChannel(cfg, guild, channelIds);
   await applyWidget(cfg, channelIds);
   await applyMemberVerification(cfg, guild);

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -387,13 +387,25 @@ function loadConfig() {
   return yaml.load(readFileSync(CONFIG_PATH, 'utf8'));
 }
 
+// branding/brand.json is the single source of truth for identity (name,
+// description, repo, guild id, invite). Cached so we read it once.
+let _brand;
+export function loadBrand() {
+  if (_brand) return _brand;
+  _brand = existsSync(BRAND_PATH) ? JSON.parse(readFileSync(BRAND_PATH, 'utf8')) : {};
+  return _brand;
+}
+
+/** "owner/name" slug from brand.repo, for GitHub API paths. */
+export function brandRepoSlug(brand = loadBrand()) {
+  const r = brand?.repo;
+  return r?.owner && r?.name ? `${r.owner}/${r.name}` : '';
+}
+
 function resolveGuildId() {
   if (process.env.DISCORD_GUILD_ID) return process.env.DISCORD_GUILD_ID;
-  if (existsSync(BRAND_PATH)) {
-    const brand = JSON.parse(readFileSync(BRAND_PATH, 'utf8'));
-    const id = brand?.community?.discord?.serverId;
-    if (id) return id;
-  }
+  const id = loadBrand()?.community?.discord?.serverId;
+  if (id) return id;
   throw new Error('DISCORD_GUILD_ID not set + brand.json::community.discord.serverId missing.');
 }
 
@@ -453,6 +465,18 @@ async function discord(method, path, body, attempt = 0) {
   }
   if (res.status === 204) return null;
   return res.json();
+}
+
+/** GET that returns null on 404 instead of throwing -- for resources that may
+ *  not exist yet on a freshly-Community guild (member-verification form,
+ *  welcome screen, onboarding), so the reconciler creates rather than dies. */
+async function discordGetOptional(path) {
+  try {
+    return await discord('GET', path);
+  } catch (e) {
+    if (/: 404\b/.test(String(e?.message))) return null;
+    throw e;
+  }
 }
 
 /**
@@ -563,9 +587,12 @@ async function applyServer(cfg) {
   const patch = {};
 
   // ── scalar settings ──
+  // Identity (name + description) is sourced from branding/brand.json so a
+  // rebrand propagates here automatically; config.yml may override.
+  const brand = loadBrand();
   const desired = {
-    name: cfg.server.name,
-    description: cfg.server.description,
+    name: cfg.server.name ?? brand.displayName ?? brand.name,
+    description: cfg.server.description ?? brand.tagline ?? brand.description ?? '',
     verification_level: cfg.server.verification_level,
     default_message_notifications: cfg.server.default_message_notifications,
     explicit_content_filter: cfg.server.explicit_content_filter,
@@ -1187,7 +1214,7 @@ async function applyOnboarding(cfg, guild, channelIds, roleIds) {
       `onboarding surfaces only ${need} channels; Discord needs >= 7 (default + prompt-referenced) to enable it.`,
     );
   }
-  const live = await discord('GET', `/guilds/${GUILD_ID}/onboarding`);
+  const live = await discordGetOptional(`/guilds/${GUILD_ID}/onboarding`);
   if (live && normalizeOnboarding(live) === normalizeOnboarding(desired)) {
     logOk('onboarding');
     return;
@@ -1218,7 +1245,7 @@ async function applyWelcome(cfg, guild, channelIds) {
       emoji_name: w.emoji_name,
     })),
   };
-  const live = await discord('GET', `/guilds/${GUILD_ID}/welcome-screen`);
+  const live = await discordGetOptional(`/guilds/${GUILD_ID}/welcome-screen`);
   if (live && normalizeWelcome(live) === normalizeWelcome(desired)) {
     logOk('welcome screen');
     return;
@@ -1368,7 +1395,7 @@ async function applyMemberVerification(cfg, guild) {
     for (const e of errors) logManual(`rules: ${e}`);
     return;
   }
-  const live = await discord('GET', `/guilds/${GUILD_ID}/member-verification`);
+  const live = await discordGetOptional(`/guilds/${GUILD_ID}/member-verification`);
   const desired = {
     enabled: true,
     description: r.description ?? '',

--- a/scripts/system/apply-discord-config.mjs
+++ b/scripts/system/apply-discord-config.mjs
@@ -247,6 +247,45 @@ export function alertChannelNames(cfg) {
   return [...names];
 }
 
+// ── Strict-prune helpers (true source-of-truth) ───────────────────
+// When `prune: true`, anything live but absent from config.yml is deleted.
+// These pure helpers compute the delete-set; the executor (pruneUndeclared)
+// does the I/O + honors dry/verify mode + a mass-delete safety cap.
+
+/** Every channel + category name config.yml declares. */
+export function declaredChannelNames(cfg) {
+  const names = [];
+  for (const cat of cfg?.categories ?? []) {
+    names.push(cat.name);
+    for (const ch of cat.channels ?? []) names.push(ch.name);
+  }
+  return names;
+}
+
+/** Live channels not in config -> prune. (Categories sort last so children
+ *  are deleted first.) */
+export function channelsToPrune(liveChannels, cfg) {
+  const declared = new Set(declaredChannelNames(cfg));
+  return (liveChannels ?? [])
+    .filter((c) => !declared.has(c.name))
+    .sort((a, b) => (a.type === 4 ? 1 : 0) - (b.type === 4 ? 1 : 0));
+}
+
+/** Live roles not in config -> prune. Never @everyone, never managed roles
+ *  (the bot's own + integration roles + the booster role are all `managed`). */
+export function rolesToPrune(liveRoles, cfg) {
+  const declared = new Set((cfg?.roles ?? []).map((r) => r.name));
+  return (liveRoles ?? []).filter(
+    (r) => r.name !== '@everyone' && !r.managed && !declared.has(r.name),
+  );
+}
+
+/** Live AutoMod rules not in config -> prune. */
+export function automodToPrune(liveRules, cfg) {
+  const declared = new Set((cfg?.automod ?? []).map((r) => r.name));
+  return (liveRules ?? []).filter((r) => !declared.has(r.name));
+}
+
 // ── Image data + apply state ──────────────────────────────────────
 // Guild image slots and the guild feature each one needs (icon needs
 // none). banner/splash/discovery_splash silently skip if the guild
@@ -1348,6 +1387,50 @@ async function applyMemberVerification(cfg, guild) {
   await discord('PATCH', `/guilds/${GUILD_ID}/member-verification`, desired);
 }
 
+// Refuse to mass-delete: a prune set this large almost always means a broken
+// config (empty/misparsed), not an intentional teardown. Surface + bail.
+const PRUNE_SAFETY_CAP = 30;
+
+/**
+ * Strict source-of-truth: delete channels / roles / AutoMod rules that exist
+ * live but aren't in config.yml. Opt-in via `prune: true`. dry/verify mode
+ * only logs the would-delete diff (discord() stubs writes); apply mode deletes.
+ * Protected: @everyone, managed roles (bot/integration/booster). Child
+ * channels are deleted before their categories.
+ */
+async function pruneUndeclared(cfg) {
+  if (!cfg.prune) return;
+  const liveChannels = (await discord('GET', `/guilds/${GUILD_ID}/channels`)) ?? [];
+  const liveRoles = (await discord('GET', `/guilds/${GUILD_ID}/roles`)) ?? [];
+  const liveRules = (await discord('GET', `/guilds/${GUILD_ID}/auto-moderation/rules`)) ?? [];
+  const chPrune = channelsToPrune(liveChannels, cfg);
+  const rolePrune = rolesToPrune(liveRoles, cfg);
+  const rulePrune = automodToPrune(liveRules, cfg);
+  const total = chPrune.length + rolePrune.length + rulePrune.length;
+  if (total === 0) {
+    logOk('prune: no undeclared resources');
+    return;
+  }
+  if (total > PRUNE_SAFETY_CAP) {
+    logManual(
+      `prune: ${total} undeclared resources exceed the safety cap (${PRUNE_SAFETY_CAP}); refusing to mass-delete. Check config.yml parsed correctly.`,
+    );
+    return;
+  }
+  for (const c of chPrune) {
+    logChange(`prune channel #${c.name}`, 'live', 'deleted');
+    await discord('DELETE', `/channels/${c.id}`);
+  }
+  for (const r of rolePrune) {
+    logChange(`prune role ${r.name}`, 'live', 'deleted');
+    await discord('DELETE', `/guilds/${GUILD_ID}/roles/${r.id}`);
+  }
+  for (const r of rulePrune) {
+    logChange(`prune automod ${r.name}`, 'live', 'deleted');
+    await discord('DELETE', `/guilds/${GUILD_ID}/auto-moderation/rules/${r.id}`);
+  }
+}
+
 // ── Main ──────────────────────────────────────────────────────────
 async function main() {
   TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -1401,6 +1484,8 @@ async function main() {
   await applyOnboarding(cfg, guild, channelIds, roleIds);
   await applyWelcome(cfg, guild, channelIds);
   await applyWebhooks(cfg);
+  // Last: delete anything live but undeclared (strict source of truth).
+  await pruneUndeclared(cfg);
 
   if (imageStateDirty) saveImageState(imageState);
 

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -10,6 +10,8 @@ import {
   automodDiffers,
   bitsToPermNames,
   buildInviteUrl,
+  alertChannelNames,
+  buildCommunityPatch,
   channelGatedOut,
   filterGrantable,
   hasFeature,
@@ -191,6 +193,29 @@ it('channelGatedOut: announcement + stage gated only on a non-COMMUNITY guild', 
   assert.equal(channelGatedOut({ type: 0 }, { features: [] }), false);
   assert.equal(channelGatedOut({ type: 2 }, { features: [] }), false);
   assert.equal(channelGatedOut({ type: 15 }, { features: [] }), false);
+});
+it('buildCommunityPatch: adds COMMUNITY (deduped) + the two channel ids', () => {
+  const p = buildCommunityPatch({ features: ['NEWS'] }, '111', '222');
+  assert.deepEqual([...p.features].sort(), ['COMMUNITY', 'NEWS']);
+  assert.equal(p.rules_channel_id, '111');
+  assert.equal(p.public_updates_channel_id, '222');
+  // already-COMMUNITY guild doesn't double it; missing features array is fine.
+  assert.deepEqual(buildCommunityPatch({ features: ['COMMUNITY'] }, '1', '2').features, [
+    'COMMUNITY',
+  ]);
+  assert.deepEqual(buildCommunityPatch({}, '1', '2').features, ['COMMUNITY']);
+});
+it('alertChannelNames: collects SEND_ALERT_MESSAGE (type 2) targets, deduped', () => {
+  const cfg = {
+    automod: [
+      { actions: [{ type: 1 }, { type: 2, metadata: { channel: 'mods' } }] },
+      { actions: [{ type: 2, metadata: { channel: 'mods' } }] }, // dup name
+      { actions: [{ type: 2, metadata: { channel: 'alerts' } }] },
+      { actions: [{ type: 2 }] }, // alert without a channel -> ignored
+    ],
+  };
+  assert.deepEqual(alertChannelNames(cfg).sort(), ['alerts', 'mods']);
+  assert.deepEqual(alertChannelNames({}), []);
 });
 it('sha256: known vector', () => {
   assert.equal(sha256('abc'), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -11,8 +11,12 @@ import {
   bitsToPermNames,
   buildInviteUrl,
   alertChannelNames,
+  automodToPrune,
   buildCommunityPatch,
   channelGatedOut,
+  channelsToPrune,
+  declaredChannelNames,
+  rolesToPrune,
   filterGrantable,
   hasFeature,
   imageDrift,
@@ -216,6 +220,48 @@ it('alertChannelNames: collects SEND_ALERT_MESSAGE (type 2) targets, deduped', (
   };
   assert.deepEqual(alertChannelNames(cfg).sort(), ['alerts', 'mods']);
   assert.deepEqual(alertChannelNames({}), []);
+});
+it('declaredChannelNames: category names + their channels', () => {
+  const cfg = {
+    categories: [{ name: 'CAT', channels: [{ name: 'a' }, { name: 'b' }] }, { name: 'EMPTY' }],
+  };
+  assert.deepEqual(declaredChannelNames(cfg).sort(), ['CAT', 'EMPTY', 'a', 'b']);
+});
+it('channelsToPrune: prunes undeclared; categories sort last (children first)', () => {
+  const cfg = { categories: [{ name: 'CAT', channels: [{ name: 'keep' }] }] };
+  const live = [
+    { id: '1', name: 'keep', type: 0 },
+    { id: '2', name: 'stray', type: 0 },
+    { id: '3', name: 'OLD CAT', type: 4 },
+  ];
+  assert.deepEqual(
+    channelsToPrune(live, cfg).map((c) => c.name),
+    ['stray', 'OLD CAT'],
+  );
+});
+it('rolesToPrune: skips @everyone + managed, prunes undeclared', () => {
+  const cfg = { roles: [{ name: 'Keep' }] };
+  const live = [
+    { id: '0', name: '@everyone' },
+    { id: '1', name: 'Keep' },
+    { id: '2', name: 'Stray' },
+    { id: '3', name: 'BotRole', managed: true }, // bot/integration/booster
+  ];
+  assert.deepEqual(
+    rolesToPrune(live, cfg).map((r) => r.name),
+    ['Stray'],
+  );
+});
+it('automodToPrune: prunes rules not in config', () => {
+  const cfg = { automod: [{ name: 'keep-rule' }] };
+  const live = [
+    { id: '1', name: 'keep-rule' },
+    { id: '2', name: 'old-rule' },
+  ];
+  assert.deepEqual(
+    automodToPrune(live, cfg).map((r) => r.name),
+    ['old-rule'],
+  );
 });
 it('sha256: known vector', () => {
   assert.equal(sha256('abc'), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -12,6 +12,7 @@ import {
   buildInviteUrl,
   alertChannelNames,
   automodToPrune,
+  brandRepoSlug,
   buildCommunityPatch,
   channelGatedOut,
   channelsToPrune,
@@ -220,6 +221,11 @@ it('alertChannelNames: collects SEND_ALERT_MESSAGE (type 2) targets, deduped', (
   };
   assert.deepEqual(alertChannelNames(cfg).sort(), ['alerts', 'mods']);
   assert.deepEqual(alertChannelNames({}), []);
+});
+it('brandRepoSlug: owner/name from brand.repo, empty when missing', () => {
+  assert.equal(brandRepoSlug({ repo: { owner: 'kaelys-js', name: 'heron' } }), 'kaelys-js/heron');
+  assert.equal(brandRepoSlug({ repo: { owner: 'o' } }), '');
+  assert.equal(brandRepoSlug({}), '');
 });
 it('declaredChannelNames: category names + their channels', () => {
   const cfg = {

--- a/scripts/system/apply-discord-config.test.mjs
+++ b/scripts/system/apply-discord-config.test.mjs
@@ -17,6 +17,7 @@ import {
   channelGatedOut,
   channelsToPrune,
   declaredChannelNames,
+  resolveBrandTokens,
   rolesToPrune,
   filterGrantable,
   hasFeature,
@@ -221,6 +222,30 @@ it('alertChannelNames: collects SEND_ALERT_MESSAGE (type 2) targets, deduped', (
   };
   assert.deepEqual(alertChannelNames(cfg).sort(), ['alerts', 'mods']);
   assert.deepEqual(alertChannelNames({}), []);
+});
+it('resolveBrandTokens: fills {{brand.PATH}} from brand; repo slug; unknown -> empty', () => {
+  const brand = {
+    displayName: 'Heron',
+    tagline: 'Stand still.',
+    colors: { primary: '#4a5b6d' },
+    repo: { owner: 'o', name: 'n' },
+  };
+  const cfg = {
+    server: { name: '{{brand.displayName}}', description: '{{brand.tagline}}' },
+    roles: [{ color: '{{brand.colors.primary}}' }],
+    slug: '{{brand.repo}}',
+    missing: '{{brand.nope}}',
+    list: ['hi {{brand.displayName}}'],
+    keep: 42,
+  };
+  const r = resolveBrandTokens(cfg, brand);
+  assert.equal(r.server.name, 'Heron');
+  assert.equal(r.server.description, 'Stand still.');
+  assert.equal(r.roles[0].color, '#4a5b6d');
+  assert.equal(r.slug, 'o/n');
+  assert.equal(r.missing, ''); // unknown token resolves to empty, not a literal brace
+  assert.equal(r.list[0], 'hi Heron');
+  assert.equal(r.keep, 42); // non-strings pass through
 });
 it('brandRepoSlug: owner/name from brand.repo, empty when missing', () => {
   assert.equal(brandRepoSlug({ repo: { owner: 'kaelys-js', name: 'heron' } }), 'kaelys-js/heron');


### PR DESCRIPTION
## Summary

Makes `maintain-discord` a true infrastructure-as-code reconciler that fully provisions the Discord server from `config.yml`, with `brand.json` as the single source of truth for identity. Builds on #124/#125. **Live-verified**: a full `apply` provisions the server green (Community enabled, all channels/roles/AutoMod/onboarding/welcome, webhooks, strict-prune deleting the default channels).

## Motivation

The reconciler was *giving up* (skipping) on resources it couldn't create instead of provisioning them, which is the opposite of what desired-state IaC should do. This PR makes it actually converge the live server to the config: enable Community programmatically, grant the bot the access it needs, prune anything undeclared, and source every brand value from `brand.json` so a rebrand re-themes the server. It also turns Discord's manual `@everyone` hardening + token-rotation hygiene into declarative/automated steps, and documents the irreducible manual steps in a complete runbook.

## What's included

- **Programmatic Community enable** (two-pass channels), **bot access provisioning** (Community + AutoMod alert channels), **strict-prune** (`prune: true`, with guardrails).
- **Brand tokens**: `{{brand.*}}` in config resolved from `brand.json` (name, tagline, colours, repo, webhook name, copy).
- **`@everyone` hardening**: `server.everyone_permissions` denies Mention-@everyone / Create-Expressions / Create-Events declaratively.
- **Token-rotation reminder** (90d), **Connected Roles scaffold**, **DISCORD.md** rewritten as a zero-to-live runbook.
- Fresh-Community 404 tolerance for member-verification / onboarding / welcome.

## Requires

The bot must hold **Administrator** (to manage private channels, enable Community, prune). Done.

## Test plan

- [x] `node scripts/system/apply-discord-config.test.mjs` — 64/64
- [x] `verify-discord-config` + actionlint + comment-style + no-slop clean
- [x] **Live**: `maintain-discord mode=apply` provisions the full server green (idempotent on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled Discord bot token-rotation reminders.
  * Connected Roles OAuth flow and one‑time role‑metadata registration.
  * Optional strict pruning to remove undeclared channels, roles, and AutoMod rules.

* **Chores**
  * Config support for prune, rules_channel, and public_updates_channel; added maintainer-only mod-updates channel and brand templating across server, roles, and webhooks.

* **Documentation**
  * Expanded Discord reconciliation docs with prune semantics, run modes, and token-rotation guidance.

* **Tests**
  * Added unit tests for reconciliation helper behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CI-STATUS-MARKER-START -->
**CI:** ✅ 2 passing
<!-- CI-STATUS-MARKER-END -->
