### PR TITLE
fix(ci): reconcile ruleset parameter drift, not just rule count

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -733,10 +733,10 @@ pre-push:
 
     # ── Shared-script unit tests ────────────────────────────────────────
     # Guard the validators that BOTH the local hooks + CI depend on, so a
-    # broken check-pr-metadata.mjs / screenshot-diff.mjs can't land. Plain
-    # Node (no vitest), <1s.
+    # broken check-pr-metadata.mjs / screenshot-diff.mjs / apply-github-config.mjs
+    # can't land. Plain Node (no vitest), <1s.
     meta-script-tests:
-      run: bash scripts/system/mise-shim.sh node scripts/system/check-pr-metadata.test.mjs && bash scripts/system/mise-shim.sh node scripts/system/screenshot-diff.test.mjs
+      run: bash scripts/system/mise-shim.sh node scripts/system/check-pr-metadata.test.mjs && bash scripts/system/mise-shim.sh node scripts/system/screenshot-diff.test.mjs && bash scripts/system/mise-shim.sh node scripts/system/apply-github-config.test.mjs
 
 # ── commit-msg (lightweight) ────────────────────────────────────────
 # Enforce Conventional Commits format (so release-please can generate

--- a/scripts/system/apply-github-config.mjs
+++ b/scripts/system/apply-github-config.mjs
@@ -44,7 +44,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execFileSync, execSync } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -117,6 +117,29 @@ function logChange(label, before, after) {
   console.log(`      - ${JSON.stringify(before)}`);
   console.log(`      + ${JSON.stringify(after)}`);
   return true;
+}
+
+/**
+ * Deep "desired is a subset of live" check. Every leaf the desired (file)
+ * config sets must equal the live value; live may carry extra keys (GitHub
+ * fills in defaults like allowed_merge_methods / required_reviewers, plus
+ * id / _links / timestamps) and those are ignored. Arrays must match length
+ * and pair up order-insensitively, so a reordered required-checks list is
+ * not false drift, but an added, removed, or changed entry is.
+ */
+export function isConfiguredSubset(desired, live) {
+  if (Array.isArray(desired)) {
+    if (!Array.isArray(live) || desired.length !== live.length) return false;
+    const matched = new Array(live.length).fill(false);
+    return desired.every((d) =>
+      live.some((l, i) => !matched[i] && isConfiguredSubset(d, l) && (matched[i] = true)),
+    );
+  }
+  if (desired !== null && typeof desired === 'object') {
+    if (live === null || typeof live !== 'object') return false;
+    return Object.keys(desired).every((k) => isConfiguredSubset(desired[k], live[k]));
+  }
+  return desired === live;
 }
 
 async function main() {
@@ -310,15 +333,15 @@ async function main() {
     if (existing) {
       // GET the full ruleset to compare (the list endpoint omits rules detail)
       const full = gh('GET', `/repos/${repoSlug}/rulesets/${existing.id}`);
-      // Cheap diff: enforce + rule count
-      const enforcementDrift = full.enforcement !== content.enforcement;
-      const ruleCountDrift = (full.rules || []).length !== (content.rules || []).length;
-      if (enforcementDrift || ruleCountDrift) {
+      // Deep subset compare: catches rule-PARAMETER drift (e.g. a flipped
+      // require_last_push_approval) that the old enforce + rule-count check
+      // silently missed, while ignoring API-added keys absent from the file.
+      const drifted = Object.keys(content).filter((k) => !isConfiguredSubset(content[k], full[k]));
+      if (drifted.length > 0) {
         driftCount++;
-        console.log(`▸ Ruleset "${content.name}" (id=${existing.id})`);
-        if (enforcementDrift) logChange('enforcement', full.enforcement, content.enforcement);
-        if (ruleCountDrift)
-          logChange('rules.length', (full.rules || []).length, (content.rules || []).length);
+        console.log(
+          `▸ Ruleset "${content.name}" (id=${existing.id}) — drift in: ${drifted.join(', ')}`,
+        );
         if (!VERIFY_ONLY && !DRY_RUN) {
           gh('PUT', `/repos/${repoSlug}/rulesets/${existing.id}`, content);
         }
@@ -351,7 +374,11 @@ async function main() {
   console.log(`\n✓ Applied ${driftCount} change(s).`);
 }
 
-main().catch((err) => {
-  console.error('::error::', err.message || err);
-  process.exit(1);
-});
+// Only run when invoked directly (`node apply-github-config.mjs`), not when
+// imported by the test, which exercises isConfiguredSubset in isolation.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('::error::', err.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/system/apply-github-config.test.mjs
+++ b/scripts/system/apply-github-config.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for isConfiguredSubset -- the ruleset drift detector in
+ * apply-github-config.mjs. It must flag rule-PARAMETER drift (e.g. a flipped
+ * require_last_push_approval) while ignoring the extra keys GitHub's rulesets
+ * API returns (allowed_merge_methods, required_reviewers, id, _links, ...).
+ * Run: `node scripts/system/apply-github-config.test.mjs`
+ */
+import { isConfiguredSubset } from './apply-github-config.mjs';
+
+let pass = 0;
+let fail = 0;
+function check(name, got, want) {
+  if (got === want) {
+    pass++;
+    console.log(`  OK  ${name}`);
+  } else {
+    fail++;
+    console.log(`  XX  ${name} (got ${got}, want ${want})`);
+  }
+}
+
+// pull_request params: the file sets 5 keys; the live API echoes those plus
+// required_reviewers + allowed_merge_methods. Subset must ignore the extras.
+const fileReview = {
+  required_approving_review_count: 1,
+  dismiss_stale_reviews_on_push: true,
+  require_code_owner_review: true,
+  require_last_push_approval: true,
+  required_review_thread_resolution: true,
+};
+const liveReviewExtraKeys = {
+  required_approving_review_count: 1,
+  dismiss_stale_reviews_on_push: true,
+  required_reviewers: [],
+  require_code_owner_review: true,
+  require_last_push_approval: true,
+  required_review_thread_resolution: true,
+  allowed_merge_methods: ['merge', 'squash', 'rebase'],
+};
+check(
+  'matching params ignore API-added keys',
+  isConfiguredSubset(fileReview, liveReviewExtraKeys),
+  true,
+);
+check(
+  'flipped require_last_push_approval is drift',
+  isConfiguredSubset(fileReview, { ...liveReviewExtraKeys, require_last_push_approval: false }),
+  false,
+);
+
+// required_status_checks flag (the second Fix 5 setting).
+check(
+  'strict_required_status_checks_policy flip is drift',
+  isConfiguredSubset(
+    { strict_required_status_checks_policy: true },
+    { strict_required_status_checks_policy: false, do_not_enforce_on_create: false },
+  ),
+  false,
+);
+
+// Arrays: order-insensitive but length-sensitive.
+check(
+  'reordered required checks are not drift',
+  isConfiguredSubset([{ context: 'A' }, { context: 'B' }], [{ context: 'B' }, { context: 'A' }]),
+  true,
+);
+check(
+  'an added required check is drift',
+  isConfiguredSubset([{ context: 'A' }], [{ context: 'A' }, { context: 'B' }]),
+  false,
+);
+check(
+  'context object ignores extra live keys',
+  isConfiguredSubset([{ context: 'A' }], [{ context: 'A', integration_id: 7 }]),
+  true,
+);
+
+// Top-level + nested.
+check(
+  'enforcement diff is drift',
+  isConfiguredSubset({ enforcement: 'active' }, { enforcement: 'disabled' }),
+  false,
+);
+check(
+  'missing nested key in live is drift',
+  isConfiguredSubset(
+    { conditions: { ref_name: { include: ['~DEFAULT_BRANCH'] } } },
+    { conditions: { ref_name: {} } },
+  ),
+  false,
+);
+check(
+  'parameter-less rule matches live with null parameters',
+  isConfiguredSubset(
+    { name: 'x', enforcement: 'active', rules: [{ type: 'deletion' }] },
+    {
+      id: 1,
+      name: 'x',
+      enforcement: 'active',
+      rules: [{ type: 'deletion', parameters: null }],
+      _links: {},
+    },
+  ),
+  true,
+);
+
+console.log(`\n${fail === 0 ? 'OK' : 'FAIL'} ${pass}/${pass + fail} test(s) passed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Follow-up to #133. When that PR enabled `require_last_push_approval` + `strict_required_status_checks_policy` in `.github/rulesets/main.json`, the `maintain-config.yml` reconciler ran green but **did not apply them to live branch protection**. Root cause: `apply-github-config.mjs` compared only `enforcement` and rule **count** -- a changed rule *parameter* (count unchanged) read as "no drift", so it never PUT the ruleset.

This replaces the cheap diff with a deep "desired is a subset of live" comparison:
- Flags any rule-parameter drift (the missed case).
- Ignores the extra keys GitHub's rulesets API returns (`allowed_merge_methods`, `required_reviewers`, `id`, `_links`, timestamps) so it does not false-positive.
- Arrays match length + pair up order-insensitively (a reordered required-checks list is not drift; an added/removed/changed one is).

Also adds a `main`-guard (so the comparison is importable), a unit test, and wires it into the pre-push `meta-script-tests` gate.

Once merged, triggering `maintain-config.yml` in apply mode reconciles the two settings onto live branch protection (closing out #133's Fix 5).

## Test plan

- [x] `node scripts/system/apply-github-config.test.mjs` -- 9/9 (flipped param, API-extra-keys ignored, reordered checks, length drift, nested miss, null-parameter rule)
- [x] `apply-github-config.mjs --verify` against live now reports `drift in: rules` (was "No drift") with exactly 1 drift item -- no false positives
- [x] biome / no-slop / comment-style / oxlint / no-deflect clean; full pre-push gauntlet (Vitest + typecheck + strict linters) green
- [ ] Post-merge: run `maintain-config.yml` (mode=apply) and confirm live ruleset shows both settings `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI-STATUS-MARKER-START -->
**CI:** ✅ 1 passing
<!-- CI-STATUS-MARKER-END -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test for configuration management script to validate subset comparison logic and ruleset drift detection.

* **Chores**
  * Updated test infrastructure to include automated validation of configuration handling.
  * Enhanced configuration drift detection with improved deep-comparison validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaelys-js/heron/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->